### PR TITLE
"group" sub-tag for entity entries allowing placing an entity in multiple groups / tabs without duplicate entries

### DIFF
--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -3772,7 +3772,10 @@ class EntityGroupModel(QAbstractListModel):
                     entitykinds[entitykind] = []
 
                 entitygroupname = en.get("Group")
-                if entitygroupname is not None and not entitygroupname in entitykinds[entitykind]:
+                if (
+                    entitygroupname is not None
+                    and not entitygroupname in entitykinds[entitykind]
+                ):
                     entitykinds[entitykind].append(entitygroupname)
 
             if self.kind is None or self.kind in entitykinds:

--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -3755,27 +3755,27 @@ class EntityGroupModel(QAbstractListModel):
         self.filter = ""
 
         for en in enList:
-            engroups = en.findall("group")
-            enkinds = {}
-            for engroup in engroups:
-                enkind = engroup.get("Kind") or en.get("Kind")
-                engroupname = engroup.get("Name") or en.get("Group")
-                if not enkind in enkinds:
-                    enkinds[enkind] = []
+            entitygroups = en.findall("group")
+            entitykinds = {}
+            for entitygroup in entitygroups:
+                entitykind = entitygroup.get("Kind") or en.get("Kind")
+                entitygroupname = entitygroup.get("Name") or en.get("Group")
+                if not entitykind in entitykinds:
+                    entitykinds[entitykind] = []
 
-                if not engroupname in enkinds[enkind]:
-                    enkinds[enkind].append(engroupname)
+                if not entitygroupname in entitykinds[entitykind]:
+                    entitykinds[entitykind].append(entitygroupname)
 
-            enkind = en.get("Kind")
-            if enkind is not None:
-                if not enkind in enkinds:
-                    enkinds[enkind] = []
+            entitykind = en.get("Kind")
+            if entitykind is not None:
+                if not entitykind in entitykinds:
+                    entitykinds[entitykind] = []
 
-                engroupname = en.get("Group")
-                if engroupname is not None and not engroupname in enkinds[enkind]:
-                    enkinds[enkind].append(engroupname)
+                entitygroupname = en.get("Group")
+                if entitygroupname is not None and not entitygroupname in entitykinds[entitykind]:
+                    entitykinds[entitykind].append(entitygroupname)
 
-            if self.kind is None or self.kind in enkinds:
+            if self.kind is None or self.kind in entitykinds:
                 t = en.get("ID")
                 variant = en.get("Variant")
                 subtype = en.get("Subtype")
@@ -3796,7 +3796,7 @@ class EntityGroupModel(QAbstractListModel):
                 e = EntityItem(en.get("Name"), t, variant, subtype, en.get("Image"))
 
                 if self.kind is not None:
-                    kindgroups = enkinds[self.kind]
+                    kindgroups = entitykinds[self.kind]
                     for g in kindgroups:
                         if g is not None:
                             if g not in self.groups:
@@ -3964,23 +3964,23 @@ class EntityPalette(QWidget):
         enList = entityXML.findall("entity")
 
         for en in enList:
-            enkinds = []
+            entitykinds = []
 
             k = en.get("Kind")
             if k is not None:
-                enkinds.append(k)
+                entitykinds.append(k)
 
-            engroups = en.findall("group")
-            for engroup in engroups:
-                engroupkind = engroup.get("Kind")
-                if engroupkind is not None:
-                    enkinds.append(engroupkind)
+            entitygroups = en.findall("group")
+            for entitygroup in entitygroups:
+                entitygroupkind = entitygroup.get("Kind")
+                if entitygroupkind is not None:
+                    entitykinds.append(entitygroupkind)
 
-            for enkind in enkinds:
-                if enkind not in groups:
-                    groups[enkind] = []
+            for entitykind in entitykinds:
+                if entitykind not in groups:
+                    groups[entitykind] = []
 
-                groups[enkind].append(en)
+                groups[entitykind].append(en)
 
         for group, ents in groups.items():
             numEnts = len(ents)

--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -3758,23 +3758,23 @@ class EntityGroupModel(QAbstractListModel):
             engroups = en.findall("group")
             enkinds = {}
             for engroup in engroups:
-                enkind = engroup.get("Kind") or en.get("Kind")                
+                enkind = engroup.get("Kind") or en.get("Kind")
                 engroupname = engroup.get("Name") or en.get("Group")
                 if not enkind in enkinds:
                     enkinds[enkind] = []
-                
+
                 if not engroupname in enkinds[enkind]:
                     enkinds[enkind].append(engroupname)
-                    
+
             enkind = en.get("Kind")
             if enkind is not None:
                 if not enkind in enkinds:
                     enkinds[enkind] = []
-            
+
                 engroupname = en.get("Group")
                 if engroupname is not None and not engroupname in enkinds[enkind]:
                     enkinds[enkind].append(engroupname)
-            
+
             if self.kind is None or self.kind in enkinds:
                 t = en.get("ID")
                 variant = en.get("Variant")
@@ -3794,20 +3794,25 @@ class EntityGroupModel(QAbstractListModel):
                     en.set("Image", "resources/Entities/questionmark.png")
 
                 e = EntityItem(en.get("Name"), t, variant, subtype, en.get("Image"))
-                
+
                 if self.kind is not None:
                     kindgroups = enkinds[self.kind]
                     for g in kindgroups:
                         if g is not None:
                             if g not in self.groups:
                                 self.groups[g] = EntityGroupItem(g)
-                            
+
                             self.groups[g].objects.append(e)
 
         i = 0
+        if "Random" in self.groups:
+            self.groups["Random"].calculateIndices(i)
+            i = self.groups["Random"].endIndex + 1
+
         for key, group in sorted(self.groups.items()):
-            group.calculateIndices(i)
-            i = group.endIndex + 1
+            if key != "Random":
+                group.calculateIndices(i)
+                i = group.endIndex + 1
 
     def rowCount(self, parent=None):
         c = 0
@@ -3956,13 +3961,23 @@ class EntityPalette(QWidget):
         enList = entityXML.findall("entity")
 
         for en in enList:
-            k = en.get("Kind")
-            if k is None:
-                continue
+            enkinds = []
 
-            if k not in groups:
-                groups[k] = []
-            groups[k].append(en)
+            k = en.get("Kind")
+            if k is not None:
+                enkinds.append(k)
+
+            engroups = en.findall("group")
+            for engroup in engroups:
+                engroupkind = engroup.get("Kind")
+                if engroupkind is not None:
+                    enkinds.append(engroupkind)
+
+            for enkind in enkinds:
+                if enkind not in groups:
+                    groups[enkind] = []
+
+                groups[enkind].append(en)
 
         for group, ents in groups.items():
             numEnts = len(ents)

--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -3976,7 +3976,7 @@ class EntityPalette(QWidget):
             entitygroups = en.findall("group")
             for entitygroup in entitygroups:
                 entitygroupkind = entitygroup.get("Kind")
-                if entitygroupkind is not None:
+                if entitygroupkind is not None and entitygroupkind not in entitykinds:
                     entitykinds.append(entitygroupkind)
 
             for entitykind in entitykinds:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Run the Latest Release
 
-The latest release can be found in the [releases tab](https://github.com/Tempus/Basement-Renovator/releases).
+The latest release can be found in the [releases tab](https://github.com/Tempus/Basement-Renovator/releases). Download the latest "BasementRenovator.zip" file, unzip it, and then double click on the Basement Renovator executable program.
 
 <br />
 

--- a/resources/EntitiesRepentance.xml
+++ b/resources/EntitiesRepentance.xml
@@ -7,15 +7,39 @@
 	<entity Group=" Random" ID="5" Image="resources/Entities/5.0.2 - Pickup.png" Kind="Pickups" Name="Pickup (not item)" Subtype="0" Variant="2" />
 	<entity Group=" Random" ID="5" Image="resources/Entities/5.0.3 - Pickup.png" Kind="Pickups" Name="Greed Pickup (no chest, item, or coin)" Subtype="0" Variant="3" />
 	<entity Group=" Random" ID="5" Image="resources/Entities/5.0.4 - Pickup.png" Kind="Pickups" Name="Pickup (no chest, item, or trinket)" Subtype="0" Variant="4" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.10.0 - RHeart.png" Kind="Pickups" Name="Random Heart" Subtype="0" Variant="10" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.20.0 - RCoin.png" Kind="Pickups" Name="Random Coin" Subtype="0" Variant="20" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.30.0 - RKey.png" Kind="Pickups" Name="Random Key" Subtype="0" Variant="30" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.40.0 - RBomb.png" Kind="Pickups" Name="Random Bomb" Subtype="0" Variant="40" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.70.0 - Random Pill.png" Kind="Pickups" Name="Random Pill" Subtype="0" Variant="70" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.301.0 - Random Rune.png" Kind="Pickups" Name="Random Rune" Subtype="0" Variant="301" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.300.0 - Random Card.png" Kind="Pickups" Name="Random Card" Subtype="0" Variant="300" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.350.0 - Trinket.png" Kind="Pickups" Name="Random Trinket" Subtype="0" Variant="350" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.90.0 - RBattery.png" Kind="Pickups" Name="Random Battery" Subtype="0" Variant="90" />
+	<entity Group=" Random" ID="5" Image="resources/Entities/5.10.0 - RHeart.png" Kind="Pickups" Name="Random Heart" Subtype="0" Variant="10">
+		<group Name="Hearts" />
+	</entity>
+	<entity Group=" Random" ID="5" Image="resources/Entities/5.20.0 - RCoin.png" Kind="Pickups" Name="Random Coin" Subtype="0" Variant="20">
+		<group Name="Coins" />
+	</entity>
+	<entity Group=" Random" ID="5" Image="resources/Entities/5.30.0 - RKey.png" Kind="Pickups" Name="Random Key" Subtype="0" Variant="30">
+		<group Name="Keys" />
+	</entity>
+	<entity Group=" Random" ID="5" Image="resources/Entities/5.40.0 - RBomb.png" Kind="Pickups" Name="Random Bomb" Subtype="0" Variant="40">
+		<group Name="Bombs" />
+	</entity>
+	<entity Group=" Random" ID="5" Image="resources/Entities/5.70.0 - Random Pill.png" Kind="Pickups" Name="Random Pill" Subtype="0" Variant="70">
+		<group Name="Pills" />
+	</entity>
+	<entity Group=" Random" ID="5" Image="resources/Entities/5.301.0 - Random Rune.png" Kind="Pickups" Name="Random Rune" Subtype="0" Variant="301">
+		<group Name="Runes" />
+	</entity>
+	<entity Group=" Random" ID="5" Image="resources/Entities/5.300.0 - Random Card.png" Kind="Pickups" Name="Random Card" Subtype="0" Variant="300">
+		<group Name="Cards" />
+	</entity>
+	<entity Group=" Random" ID="5" Image="resources/Entities/Items/5.100.0 - Random.png" Kind="Pickups" Name="Random Collectible" Subtype="0" Variant="100">
+		<group Kind="Collect" />
+	</entity>
+	<entity Group=" Random" ID="5" Image="resources/Entities/Items/5.150.0 - Random.png" Kind="Pickups" Name="Random Shop Item" Subtype="0" Variant="150">
+		<group Kind="Collect" />
+	</entity>
+	<entity Group=" Random" ID="5" Image="resources/Entities/5.350.0 - Trinket.png" Kind="Pickups" Name="Random Trinket" Subtype="0" Variant="350" >
+		<group Kind="Collect" />
+	</entity>
+	<entity Group=" Random" ID="5" Image="resources/Entities/5.90.0 - RBattery.png" Kind="Pickups" Name="Random Battery" Subtype="0" Variant="90">
+		<group Name="Batteries" />
+	</entity>
 	<entity Group=" Random" ID="5" Image="resources/Entities/5.69.0 - RGrab Bag.png" Kind="Pickups" Name="Random Grab Bag" Subtype="0" Variant="69" />
 
 	<!-- Bombs -->
@@ -116,7 +140,6 @@
 	<entity Group="Chests" ID="5" Image="resources/Entities/5.69.2 - Black Sack.png" Kind="Pickups" Name="Black Sack" Variant="69" Subtype="2" />
 
 	<!-- Coins -->
-	<entity Group="Coins" ID="5" Image="resources/Entities/5.20.0 - RCoin.png" Kind="Pickups" Name="Random Coin" Subtype="0" Variant="20" />
 	<entity Group="Coins" ID="5" Image="resources/Entities/5.20.1 - Penny.png" Kind="Pickups" Name="Penny" Subtype="1" Variant="20" />
 	<entity Group="Coins" ID="5" Image="resources/Entities/5.20.4 - Double Penny.png" Kind="Pickups" Name="Double Penny" Subtype="4" Variant="20" />
 	<entity Group="Coins" ID="5" Image="resources/Entities/5.20.2 - Nickel.png" Kind="Pickups" Name="Nickel" Subtype="2" Variant="20" />
@@ -1120,11 +1143,6 @@
 	<entity Group="Troll Bombs" ID="5" Image="resources/Entities/5.40.6 - Golden Troll Bomb.png" Kind="Stage" Name="Golden Troll Bomb" Variant="40" Subtype="6" />
 
 	<!--——— Collect ———-->
-
-	<!-- Random -->
-	<entity Group=" Random" ID="5" Image="resources/Entities/Items/5.100.0 - Random.png" Kind="Collect" Name="Random Collectible" Subtype="0" Variant="100" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/Items/5.150.0 - Random.png" Kind="Collect" Name="Random Shop Item" Subtype="0" Variant="150" />
-	<entity Group=" Random" ID="5" Image="resources/Entities/5.350.0 - Trinket.png" Kind="Collect" Name="Random Trinket" Subtype="0" Variant="350" />
 
 	<!-- Active Items -->
 	<entity Group="Active Items" ID="5" Image="resources/Entities/Items/5.100.33 - The Bible.png" Kind="Collect" Name="The Bible" Subtype="33" Variant="100" />

--- a/resources/EntitiesRepentance.xml
+++ b/resources/EntitiesRepentance.xml
@@ -41,7 +41,7 @@
 		<group Name="Batteries" />
 	</entity>
 	<entity Group="Random" ID="5" Image="resources/Entities/5.69.0 - RGrab Bag.png" Kind="Pickups" Name="Random Grab Bag" Subtype="0" Variant="69" />
-	
+
 	<!-- Bombs -->
 	<entity Group="Bombs" ID="5" Image="resources/Entities/5.40.1 - Bomb.png" Kind="Pickups" Name="Bomb" Subtype="1" Variant="40" />
 	<entity Group="Bombs" ID="5" Image="resources/Entities/5.40.2 - Double Bomb.png" Kind="Pickups" Name="Double Bomb" Subtype="2" Variant="40" />

--- a/resources/EntitiesRepentance.xml
+++ b/resources/EntitiesRepentance.xml
@@ -2,6 +2,15 @@
 	<!--——— Pickups ———-->
 
 	<!-- Random -->
+	<entity Group="Random" ID="5" Image="resources/Entities/Items/5.100.0 - Random.png" Kind="Pickups" Name="Random Collectible" Subtype="0" Variant="100">
+		<group Kind="Collect" />
+	</entity>
+	<entity Group="Random" ID="5" Image="resources/Entities/Items/5.150.0 - Random.png" Kind="Pickups" Name="Random Shop Item" Subtype="0" Variant="150">
+		<group Kind="Collect" />
+	</entity>
+	<entity Group="Random" ID="5" Image="resources/Entities/5.350.0 - Trinket.png" Kind="Pickups" Name="Random Trinket" Subtype="0" Variant="350" >
+		<group Kind="Collect" />
+	</entity>
 	<entity Group="Random" ID="5" Image="resources/Entities/5.0.0 - Pickup.png" Kind="Pickups" Name="Pickup" Subtype="0" Variant="0" />
 	<entity Group="Random" ID="5" Image="resources/Entities/5.0.1 - Pickup.png" Kind="Pickups" Name="Pickup (not chest or item)" Subtype="0" Variant="1" />
 	<entity Group="Random" ID="5" Image="resources/Entities/5.0.2 - Pickup.png" Kind="Pickups" Name="Pickup (not item)" Subtype="0" Variant="2" />
@@ -28,22 +37,12 @@
 	<entity Group="Random" ID="5" Image="resources/Entities/5.300.0 - Random Card.png" Kind="Pickups" Name="Random Card" Subtype="0" Variant="300">
 		<group Name="Cards" />
 	</entity>
-	<entity Group="Random" ID="5" Image="resources/Entities/Items/5.100.0 - Random.png" Kind="Pickups" Name="Random Collectible" Subtype="0" Variant="100">
-		<group Kind="Collect" />
-	</entity>
-	<entity Group="Random" ID="5" Image="resources/Entities/Items/5.150.0 - Random.png" Kind="Pickups" Name="Random Shop Item" Subtype="0" Variant="150">
-		<group Kind="Collect" />
-	</entity>
-	<entity Group="Random" ID="5" Image="resources/Entities/5.350.0 - Trinket.png" Kind="Pickups" Name="Random Trinket" Subtype="0" Variant="350" >
-		<group Kind="Collect" />
-	</entity>
 	<entity Group="Random" ID="5" Image="resources/Entities/5.90.0 - RBattery.png" Kind="Pickups" Name="Random Battery" Subtype="0" Variant="90">
 		<group Name="Batteries" />
 	</entity>
 	<entity Group="Random" ID="5" Image="resources/Entities/5.69.0 - RGrab Bag.png" Kind="Pickups" Name="Random Grab Bag" Subtype="0" Variant="69" />
 	
 	<!-- Bombs -->
-	<entity Group="Bombs" ID="5" Image="resources/Entities/5.40.0 - RBomb.png" Kind="Pickups" Name="Random Bomb" Subtype="0" Variant="40" />
 	<entity Group="Bombs" ID="5" Image="resources/Entities/5.40.1 - Bomb.png" Kind="Pickups" Name="Bomb" Subtype="1" Variant="40" />
 	<entity Group="Bombs" ID="5" Image="resources/Entities/5.40.2 - Double Bomb.png" Kind="Pickups" Name="Double Bomb" Subtype="2" Variant="40" />
 	<entity Group="Bombs" ID="5" Image="resources/Entities/5.40.4 - Golden Bomb.png" Kind="Pickups" Name="Golden Bomb" Subtype="4" Variant="40" />
@@ -53,7 +52,6 @@
 	<entity Group="Bombs" ID="5" Image="resources/Entities/5.42.1 - Big Poop Nugget.png" Kind="Pickups" Name="Big Poop Nugget" Variant="42" Subtype="1" />
 
 	<!-- Cards -->
-	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.0 - Random Card.png" Kind="Pickups" Name="Random Card" Subtype="0" Variant="300" />
 	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.1 - The Fool.png" Kind="Pickups" Name="The Fool" Subtype="1" Variant="300" />
 	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.2 - The Magician.png" Kind="Pickups" Name="The Magician" Subtype="2" Variant="300" />
 	<entity Group="Cards" ID="5" Image="resources/Entities/5.300.3 - The High Priestess.png" Kind="Pickups" Name="The High Priestess" Subtype="3" Variant="300" />
@@ -149,7 +147,6 @@
 	<entity Group="Coins" ID="5" Image="resources/Entities/5.20.7 - Golden Penny.png" Kind="Pickups" Name="Golden Penny" Variant="20" Subtype="7" />
 
 	<!-- Hearts -->
-	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.0 - RHeart.png" Kind="Pickups" Name="Random Heart" Subtype="0" Variant="10" />
 	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.1 - Heart.png" Kind="Pickups" Name="Heart" Subtype="1" Variant="10" />
 	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.2 - Heart (half).png" Kind="Pickups" Name="Heart (half)" Subtype="2" Variant="10" />
 	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.5 - Heart (double).png" Kind="Pickups" Name="Heart (double)" Subtype="5" Variant="10" />
@@ -164,14 +161,12 @@
 	<entity Group="Hearts" ID="5" Image="resources/Entities/5.10.12 - Rotten Heart.png" Kind="Pickups" Name="Heart (rotten)" Subtype="12" Variant="10"/>
 
 	<!-- Keys -->
-	<entity Group="Keys" ID="5" Image="resources/Entities/5.30.0 - RKey.png" Kind="Pickups" Name="Random Key" Subtype="0" Variant="30" />
 	<entity Group="Keys" ID="5" Image="resources/Entities/5.30.1 - Key.png" Kind="Pickups" Name="Key" Subtype="1" Variant="30" />
 	<entity Group="Keys" ID="5" Image="resources/Entities/5.30.3 - Key Ring.png" Kind="Pickups" Name="Key Ring" Subtype="3" Variant="30" />
 	<entity Group="Keys" ID="5" Image="resources/Entities/5.30.2 - Golden Key.png" Kind="Pickups" Name="Golden Key" Subtype="2" Variant="30" />
 	<entity Group="Keys" ID="5" Image="resources/Entities/5.30.4 - Charged Key.png" Kind="Pickups" Name="Charged Key" Subtype="4" Variant="30" />
 
 	<!-- Pills -->
-	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.0 - Random Pill.png" Kind="Pickups" Name="Random Pill" Subtype="0" Variant="70" />
 	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.1 - Blue Pill.png" Kind="Pickups" Name="Blue Pill" Subtype="1" Variant="70" />
 	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.2 - White-Blue Pill.png" Kind="Pickups" Name="White-Blue Pill" Subtype="2" Variant="70" />
 	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.3 - Orange Pill.png" Kind="Pickups" Name="Orange Pill" Subtype="3" Variant="70" />
@@ -202,7 +197,6 @@
 	<entity Group="Pills" ID="5" Image="resources/Entities/5.70.2062 - Horse Pill Gold-Gold.png" Kind="Pickups" Name="Horse Pill Gold-Gold" Variant="70" Subtype="2062" />
 
 	<!-- Runes -->
-	<entity Group="Runes" ID="5" Image="resources/Entities/5.301.0 - Random Rune.png" Kind="Pickups" Name="Random Rune" Subtype="0" Variant="301" />
 	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.32 - Hagalaz.png" Kind="Pickups" Name="Hagalaz" Subtype="32" Variant="300" />
 	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.33 - Jera.png" Kind="Pickups" Name="Jera" Subtype="33" Variant="300" />
 	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.34 - Ehwaz.png" Kind="Pickups" Name="Ehwaz" Subtype="34" Variant="300" />
@@ -233,7 +227,6 @@
 	<entity Group="Runes" ID="5" Image="resources/Entities/5.300.97 - Soul of Jacob and Esau.png" Kind="Pickups" Name="Soul of Jacob and Esau" Subtype="97" Variant="300" />
 
 	<!-- Batteries -->
-	<entity Group="Batteries" ID="5" Image="resources/Entities/5.90.0 - RBattery.png" Kind="Pickups" Name="Random Battery" Subtype="0" Variant="90" />
 	<entity Group="Batteries" ID="5" Image="resources/Entities/5.90.1 - Lil' Battery.png" Kind="Pickups" Name="Lil' Battery" Variant="90" Subtype="1" />
 	<entity Group="Batteries" ID="5" Image="resources/Entities/5.90.2 - Micro Battery.png" Kind="Pickups" Name="Micro Battery" Variant="90" Subtype="2" />
 	<entity Group="Batteries" ID="5" Image="resources/Entities/5.90.3 - Mega Battery.png" Kind="Pickups" Name="Mega Battery" Variant="90" Subtype="3" />


### PR DESCRIPTION
Allows adding additional groups or kinds to entities with a sub tag, like so:
```xml
<entity Group="Random" ID="5" Image="resources/Entities/5.90.0 - RBattery.png" Kind="Pickups" Name="Random Battery" Subtype="0" Variant="90">
	<group Name="Batteries" />
</entity>
```
The group's Name will default to the entity's Group tag if not specified, and the group's Kind will default to the entity's Kind tag similarly.

Duplicate entries for the same entity still work for this purpose, but I've replaced the ones in `EntitiesRepentance.xml` with this system. I haven't gone through the older xml versions to remove duplicate entries yet.

Also forces groups named "Random" to the top of the list via hardcoding to get rid of the " Random" issue; this should probably be changed later to a more flexible system.
