### PR TITLE
New "Bitmap" bitfield element widget type

### DIFF
--- a/src/lookup.py
+++ b/src/lookup.py
@@ -404,6 +404,10 @@ class EntityLookup(Lookup):
                         self.dropdownkeys.append(value.text)
                         self.dropdownvalues.append(int(value.get("Value", i)))
 
+                self.gridwidth = None
+                if self.widget == "bitmap":
+                    self.gridwidth = int(node.get("Width", self.length))
+
             def getRawValue(self, number):
                 number = bitGet(number, self.offset, self.length)
 


### PR DESCRIPTION
Adds a new type of widget usable by the entity parameters system, the bitmap. It's a collection of checkboxes that each represent one bit in the final value.
![image](https://user-images.githubusercontent.com/11726474/162034661-0a61b509-7dd8-4abe-8eb7-3eaa3f1f375c.png)

Grid width and total size of the bitmap are configurable with the Width and Length properties, e.g:
`<bitmap Name="Funky Bitmap" Length="16" Width="4"/>` creates the bitmap shown above.