### PR TITLE
Fix bitfields interfering with entity gfx overrides

### DIFF
--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -1381,19 +1381,17 @@ class Entity(QGraphicsItem):
         if gfxData is None:
             return None
 
-        type, variant, subtype = self.entity.Type, self.entity.Variant, self.entity.Subtype
+        variant = self.entity.Variant
+        subtype = self.entity.Subtype
+
         if self.entity.config.hasBitfields:
-            hasVariantBitfield = self.entity.config.hasBitfieldKey("Variant")
-            hasSubtypeBitfield = self.entity.config.hasBitfieldKey("Subtype")
+            if self.entity.config.hasBitfieldKey("Subtype"):
+                subtype = 0
 
-            if hasVariantBitfield and hasSubtypeBitfield:
-                entID = f"{type}.0.0"
-            elif hasSubtypeBitfield:
-                entID = f"{type}.{variant}.0"
-            elif hasVariantBitfield:
-                entID = f"{variant}.0.{subtype}"
+            if self.entity.config.hasBitfieldKey("Variant"):
+                variant = 0
 
-        entID = f"{type}.{variant}.{subtype}"
+        entID = f"{self.entity.Type}.{variant}.{subtype}"
 
         return gfxData["Entities"].get(entID)
 

--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -1382,6 +1382,13 @@ class Entity(QGraphicsItem):
             return None
 
         entID = f"{self.entity.Type}.{self.entity.Variant}.{self.entity.Subtype}"
+
+        if self.entity.config.hasBitfields:
+            if self.entity.config.hasBitfieldKey("Variant"):
+                entID = f"{self.entity.Type}.0.0"
+            elif self.entity.config.hasBitfieldKey("Subtype"):
+                entID = f"{self.entity.Type}.{self.entity.Variant}.0"
+
         return gfxData["Entities"].get(entID)
 
     def getCurrentImg(self):

--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -1381,18 +1381,14 @@ class Entity(QGraphicsItem):
         if gfxData is None:
             return None
 
-        entID = f"{self.entity.Type}.{self.entity.Variant}.{self.entity.Subtype}"
-
+        variant, subtype = self.entity.Variant, self.entity.Subtype
         if self.entity.config.hasBitfields:
-            hasVariantBitfield = self.entity.config.hasBitfieldKey("Variant")
-            hasSubtypeBitfield = self.entity.config.hasBitfieldKey("Subtype")
-
-            if hasVariantBitfield and hasSubtypeBitfield:
-                entID = f"{self.entity.Type}.0.0"
-            elif hasVariantBitfield:
-                entID = f"{self.entity.Type}.0.{self.entity.Subtype}"
-            elif hasSubtypeBitfield:
-                entID = f"{self.entity.Type}.{self.entity.Variant}.0"
+            if self.entity.config.hasBitfieldKey("Variant"):
+                variant = 0
+            if self.entity.config.hasBitfieldKey("Subtype"):
+                subtype = 0
+        
+        entID = f"{self.entity.Type}.{variant}.{subtype}"
 
         return gfxData["Entities"].get(entID)
 

--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -1384,9 +1384,14 @@ class Entity(QGraphicsItem):
         entID = f"{self.entity.Type}.{self.entity.Variant}.{self.entity.Subtype}"
 
         if self.entity.config.hasBitfields:
-            if self.entity.config.hasBitfieldKey("Variant"):
+            hasVariantBitfield = self.entity.config.hasBitfieldKey("Variant")
+            hasSubtypeBitfield = self.entity.config.hasBitfieldKey("Subtype")
+
+            if hasVariantBitfield and hasSubtypeBitfield:
                 entID = f"{self.entity.Type}.0.0"
-            elif self.entity.config.hasBitfieldKey("Subtype"):
+            elif hasVariantBitfield:
+                entID = f"{self.entity.Type}.0.{self.entity.Subtype}"
+            elif hasSubtypeBitfield:
                 entID = f"{self.entity.Type}.{self.entity.Variant}.0"
 
         return gfxData["Entities"].get(entID)

--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -1381,14 +1381,19 @@ class Entity(QGraphicsItem):
         if gfxData is None:
             return None
 
-        variant, subtype = self.entity.Variant, self.entity.Subtype
+        type, variant, subtype = self.entity.Type, self.entity.Variant, self.entity.Subtype
         if self.entity.config.hasBitfields:
-            if self.entity.config.hasBitfieldKey("Variant"):
-                variant = 0
-            if self.entity.config.hasBitfieldKey("Subtype"):
-                subtype = 0
-        
-        entID = f"{self.entity.Type}.{variant}.{subtype}"
+            hasVariantBitfield = self.entity.config.hasBitfieldKey("Variant")
+            hasSubtypeBitfield = self.entity.config.hasBitfieldKey("Subtype")
+
+            if hasVariantBitfield and hasSubtypeBitfield:
+                entID = f"{type}.0.0"
+            elif hasSubtypeBitfield:
+                entID = f"{type}.{variant}.0"
+            elif hasVariantBitfield:
+                entID = f"{variant}.0.{subtype}"
+
+        entID = f"{type}.{variant}.{subtype}"
 
         return gfxData["Entities"].get(entID)
 


### PR DESCRIPTION
Entities with bitfields will not lose their gfx override when changing their Variant/Subtype (depending on what bitfields they have)