### PR TITLE
Add setting to disable in-game UI + add Migraine to alt Ch2 shared enemies

### DIFF
--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -5149,6 +5149,11 @@ class MainWindow(QMainWindow):
         )
         self.rd.setCheckable(True)
         self.rd.setChecked(settings.value("DisableTestDialog") != "1")
+        self.rg = r.addAction(
+            "Disable In-Game UI", lambda: self.toggleSetting("DisableInGameUI")
+        )
+        self.rg.setCheckable(True)
+        self.rg.setChecked(settings.value("DisableInGameUI") == "1")
 
         h = mb.addMenu("Help")
         self.ha = h.addAction("About Basement Renovator", self.aboutDialog)
@@ -6017,9 +6022,10 @@ class MainWindow(QMainWindow):
     StageType = {floorInfo.get('StageType')},
     StageName = {strFix(floorInfo.get('Name'))},
     IsModStage = {floorInfo.get('BaseGamePath') is None and 'true' or 'false'},
+    DisableUI = {settings.value("DisableInGameUI")},
     RoomFile = {strFix(str(Path(self.path)) or 'N/A')},
     Rooms = {{
-    {roomsStr}
+        {roomsStr}
     }}
 }}
 """

--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -6022,7 +6022,7 @@ class MainWindow(QMainWindow):
     StageType = {floorInfo.get('StageType')},
     StageName = {strFix(floorInfo.get('Name'))},
     IsModStage = {floorInfo.get('BaseGamePath') is None and 'true' or 'false'},
-    DisableUI = {settings.value("DisableInGameUI")},
+    DisableUI = {settings.value("DisableInGameUI") == "1" and 'true' or 'false'},
     RoomFile = {strFix(str(Path(self.path)) or 'N/A')},
     Rooms = {{
         {roomsStr}

--- a/README.md
+++ b/README.md
@@ -65,12 +65,15 @@ The latest version of Basement Renovator is available in the [releases section](
         - Toggle whether to stay at the current door using `;`
         - Invalid doors for the room will be indicated by a red barred door
     - Works most like the base game when testing one room at a time
+  - The in-game info text and colored doors can be hidden by enabling the "Disable In-Game UI" setting
+    - This setting can also be toggled in-game using `'`
+
 
 ### F.A.Q.
 
 *The 'InstaPreview' tool isn't working for me; what can I do?*
 - Open `settings.ini` in the BR folder in a text editor. Ensure there is a line that says: `InstallFolder=(...)` where (...) is the location of the TBOI install folder containing an executable
- 
+
 *How do I edit Repentance rooms?*
 
 - Open `settings.ini` in the BR folder in a text editor. Add a line that says: `CompatibilityMode=Repentance`. Other valid values are `Rebirth`, `Afterbirth`, `Afterbirth+`, and `Antibirth`

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The latest version of Basement Renovator is available in the [releases section](
         - Invalid doors for the room will be indicated by a red barred door
     - Works most like the base game when testing one room at a time
   - The in-game info text and colored doors can be hidden by enabling the "Disable In-Game UI" setting
-    - This setting can also be toggled in-game using `'`
+    - This setting can also be toggled in-game using `u`
 
 
 ### F.A.Q.

--- a/resources/EntitiesRepentance.xml
+++ b/resources/EntitiesRepentance.xml
@@ -581,6 +581,7 @@
     <entity Name="Bony" />
     <entity Name="Gurgle" />
     <entity Name="Splasher" />
+    <entity Name="Migraine" />
     <entity BaseHP="20" Tags="Champion" ID="821" Image="Entities/821.0.0 - Blaster.png" Name="Blaster" Variant="0" Subtype="0" />
     <entity BaseHP="40" Tags="Champion" ID="820" Image="Entities/820.1.0 - Coal Boy.png" Name="Coal Boy" Variant="1" Subtype="0" />
     <entity BaseHP="10" Tags="Champion" ID="61" Image="Entities/61.3.0 - Ink.png" Name="Ink" Variant="3" Subtype="0" />

--- a/resources/modtemplate/main.lua
+++ b/resources/modtemplate/main.lua
@@ -346,25 +346,27 @@ function BasementRenovator.RenderDoorSlots(room, doorSlots, enterSlot)
     end
 
     -- render invalid door slots as effects
-    for _, slot in pairs(doorSlots) do
-        local doorDir = DoorToDirection[slot]
+    if BasementRenovator.TestRoomData.DisableUI ~= 1 then
+        for _, slot in pairs(doorSlots) do
+            local doorDir = DoorToDirection[slot]
 
-        local door = Isaac.Spawn(1000, FakeDoorVariant, 0, room:GetDoorSlotPosition(slot), veczero, nil)
-        local sprite = door:GetSprite()
-        sprite.Rotation = DirectionToDegrees(doorDir)
-        sprite.Offset = DoorOffsetsByDirection[doorDir]
+            local door = Isaac.Spawn(1000, FakeDoorVariant, 0, room:GetDoorSlotPosition(slot), veczero, nil)
+            local sprite = door:GetSprite()
+            sprite.Rotation = DirectionToDegrees(doorDir)
+            sprite.Offset = DoorOffsetsByDirection[doorDir]
 
-        if not room:IsDoorSlotAllowed(slot) then
-            sprite:ReplaceSpritesheet(0, 'basementrenovator/grid/invaliddoor.png')
-            sprite:ReplaceSpritesheet(1, 'basementrenovator/grid/invaliddoor.png')
-            sprite:ReplaceSpritesheet(2, 'basementrenovator/grid/invaliddoor.png')
-            sprite:ReplaceSpritesheet(3, 'basementrenovator/grid/invaliddoor.png')
-            sprite:LoadGraphics()
-            sprite:Play('Closed', true)
-            door:AddEntityFlags(EntityFlag.FLAG_RENDER_WALL)
-        elseif slot == enterSlot then
-            sprite:ReplaceSpritesheet(3, 'basementrenovator/grid/entrydoor.png')
-            sprite:LoadGraphics()
+            if not room:IsDoorSlotAllowed(slot) then
+                sprite:ReplaceSpritesheet(0, 'basementrenovator/grid/invaliddoor.png')
+                sprite:ReplaceSpritesheet(1, 'basementrenovator/grid/invaliddoor.png')
+                sprite:ReplaceSpritesheet(2, 'basementrenovator/grid/invaliddoor.png')
+                sprite:ReplaceSpritesheet(3, 'basementrenovator/grid/invaliddoor.png')
+                sprite:LoadGraphics()
+                sprite:Play('Closed', true)
+                door:AddEntityFlags(EntityFlag.FLAG_RENDER_WALL)
+            elseif slot == enterSlot then
+                sprite:ReplaceSpritesheet(3, 'basementrenovator/grid/entrydoor.png')
+                sprite:LoadGraphics()
+            end
         end
     end
 end
@@ -483,13 +485,17 @@ BasementRenovator.mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
 
     local topLeft = game:GetRoom():GetRenderSurfaceTopLeft()
     local pos = Vector(20, topLeft.Y * 2 + 286) --Vector(442,286)
-    Isaac.RenderScaledText("BASEMENT RENOVATOR TEST: " .. room.Name .. " (" .. room.Variant .. ", Difficulty: " .. roomDesc.Data.Difficulty .. ") [" .. filename .. ']', pos.X, pos.Y - 28, 0.5, 0.5, 255, 255, 0, 0.75)
-    Isaac.RenderScaledText("Test Type: " .. test.TestType ..  " --- In Test Room: " .. (room.Invalid and 'NO' or ('YES' .. (BasementRenovator.LockDoorSlot and ' [DOOR SLOT LOCKED]' or ''))), pos.X, pos.Y - 20, 0.5, 0.5, 255, 255, 0, 0.75)
+    if BasementRenovator.TestRoomData.DisableUI ~= 1 then
+        Isaac.RenderScaledText("BASEMENT RENOVATOR TEST: " .. room.Name .. " (" .. room.Variant .. ", Difficulty: " .. roomDesc.Data.Difficulty .. ") [" .. filename .. ']', pos.X, pos.Y - 28, 0.5, 0.5, 255, 255, 0, 0.75)
+        Isaac.RenderScaledText("Test Type: " .. test.TestType ..  " --- In Test Room: " .. (room.Invalid and 'NO' or ('YES' .. (BasementRenovator.LockDoorSlot and ' [DOOR SLOT LOCKED]' or ''))), pos.X, pos.Y - 20, 0.5, 0.5, 255, 255, 0, 0.75)
+    end
 
     local enableCycling = false
     if #test.Rooms > 1 and test.TestType == 'InstaPreview' then
         enableCycling = true
-        Isaac.RenderScaledText("Press . (period) to cycle forward and , (comma) to go back. Current: " .. (test.CurrentIndex + 1) .. '/' .. #test.Rooms, pos.X, pos.Y - 36, 0.5, 0.5, 0, 255, 255, 0.75)
+        if not BasementRenovator.TestRoomData.DisableUI ~= 1 then
+            Isaac.RenderScaledText("Press . (period) to cycle forward and , (comma) to go back. Current: " .. (test.CurrentIndex + 1) .. '/' .. #test.Rooms, pos.X, pos.Y - 36, 0.5, 0.5, 0, 255, 255, 0.75)
+        end
     end
 
     local frame = game:GetFrameCount()

--- a/resources/modtemplate/main.lua
+++ b/resources/modtemplate/main.lua
@@ -493,7 +493,7 @@ BasementRenovator.mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
     local enableCycling = false
     if #test.Rooms > 1 and test.TestType == 'InstaPreview' then
         enableCycling = true
-        if not BasementRenovator.TestRoomData.DisableUI ~= 1 then
+        if BasementRenovator.TestRoomData.DisableUI ~= 1 then
             Isaac.RenderScaledText("Press . (period) to cycle forward and , (comma) to go back. Current: " .. (test.CurrentIndex + 1) .. '/' .. #test.Rooms, pos.X, pos.Y - 36, 0.5, 0.5, 0, 255, 255, 0.75)
         end
     end

--- a/resources/modtemplate/main.lua
+++ b/resources/modtemplate/main.lua
@@ -49,6 +49,7 @@ end
 
 local RoomIndex = {}
 
+BasementRenovator.DisableUI = false
 if not BasementRenovator.TestRoomData then
     log('No room to test; please disable the mod')
     return
@@ -67,6 +68,7 @@ else
 
         room.Index = i
     end
+    BasementRenovator.DisableUI = roomData.DisableUI
     roomData.CurrentIndex = 0
 end
 
@@ -346,7 +348,7 @@ function BasementRenovator.RenderDoorSlots(room, doorSlots, enterSlot)
     end
 
     -- render invalid door slots as effects
-    if BasementRenovator.TestRoomData.DisableUI ~= 1 then
+    if not BasementRenovator.DisableUI then
         for _, slot in pairs(doorSlots) do
             local doorDir = DoorToDirection[slot]
 
@@ -485,7 +487,7 @@ BasementRenovator.mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
 
     local topLeft = game:GetRoom():GetRenderSurfaceTopLeft()
     local pos = Vector(20, topLeft.Y * 2 + 286) --Vector(442,286)
-    if BasementRenovator.TestRoomData.DisableUI ~= 1 then
+    if not BasementRenovator.DisableUI then
         Isaac.RenderScaledText("BASEMENT RENOVATOR TEST: " .. room.Name .. " (" .. room.Variant .. ", Difficulty: " .. roomDesc.Data.Difficulty .. ") [" .. filename .. ']', pos.X, pos.Y - 28, 0.5, 0.5, 255, 255, 0, 0.75)
         Isaac.RenderScaledText("Test Type: " .. test.TestType ..  " --- In Test Room: " .. (room.Invalid and 'NO' or ('YES' .. (BasementRenovator.LockDoorSlot and ' [DOOR SLOT LOCKED]' or ''))), pos.X, pos.Y - 20, 0.5, 0.5, 255, 255, 0, 0.75)
     end
@@ -493,7 +495,7 @@ BasementRenovator.mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
     local enableCycling = false
     if #test.Rooms > 1 and test.TestType == 'InstaPreview' then
         enableCycling = true
-        if BasementRenovator.TestRoomData.DisableUI ~= 1 then
+        if not BasementRenovator.DisableUI then
             Isaac.RenderScaledText("Press . (period) to cycle forward and , (comma) to go back. Current: " .. (test.CurrentIndex + 1) .. '/' .. #test.Rooms, pos.X, pos.Y - 36, 0.5, 0.5, 0, 255, 255, 0.75)
         end
     end
@@ -511,6 +513,10 @@ BasementRenovator.mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
         if SafeKeyboardTriggered(Keyboard.KEY_SEMICOLON, ci) then
             -- toggle lock door slot
             BasementRenovator.LockDoorSlot = not BasementRenovator.LockDoorSlot
+        end
+
+        if SafeKeyboardTriggered(Keyboard.KEY_APOSTROPHE, ci) then
+            BasementRenovator.DisableUI = not BasementRenovator.DisableUI
         end
 
         if enableCycling then

--- a/resources/modtemplate/main.lua
+++ b/resources/modtemplate/main.lua
@@ -515,7 +515,7 @@ BasementRenovator.mod:AddCallback(ModCallbacks.MC_POST_RENDER, function()
             BasementRenovator.LockDoorSlot = not BasementRenovator.LockDoorSlot
         end
 
-        if SafeKeyboardTriggered(Keyboard.KEY_APOSTROPHE, ci) then
+        if SafeKeyboardTriggered(Keyboard.KEY_U, ci) then
             BasementRenovator.DisableUI = not BasementRenovator.DisableUI
         end
 


### PR DESCRIPTION
Setting is labeled "Disable In-Game UI" under the Test tab. When enabled, rendered text and door sprites associated with the BR test mod will be disabled, which is ideal for when aesthetically pleasing screenshots or footage is desired. 