### PR TITLE
Make NEW_ROOM callback be prioritized

### DIFF
--- a/resources/modtemplate/main.lua
+++ b/resources/modtemplate/main.lua
@@ -373,7 +373,7 @@ function BasementRenovator.RenderDoorSlots(room, doorSlots, enterSlot)
     end
 end
 
-BasementRenovator.mod:AddCallback(ModCallbacks.MC_POST_NEW_ROOM, function()
+BasementRenovator.mod:AddPriorityCallback(ModCallbacks.MC_POST_NEW_ROOM, CallbackPriority.IMPORTANT, function()
     local test = BasementRenovator.TestRoomData
     local testRoom = BasementRenovator:InTestRoom()
     if testRoom then


### PR DESCRIPTION
This fixes strange interactions with other mods by making sure the player's position is updated before they run their new room code