### PR TITLE
Pit tiling with other tiles

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Basement Renovator",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/BasementRenovator.py",
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -1199,12 +1199,13 @@ class Entity(QGraphicsItem):
     RockAnm2 = anm2.Config("resources/Backgrounds/RockGrid.anm2", "resources")
     RockAnm2.setAnimation()
 
-    def getPitFrame(self, pitImg, rendered):
+    def getPitFrame(self, pitImg, rendered, extraConnections: 'list|None'):
         def matchInStack(stack):
             for ent in stack:
                 img = ent.getCurrentImg()
 
-                if img == pitImg:
+                # printf(f"DEBUG: extraConnections is {extraConnections}, {extraConnections and img in extraConnections}")
+                if img == pitImg or (extraConnections and img in extraConnections):
                     return True
 
             return False
@@ -1551,7 +1552,7 @@ class Entity(QGraphicsItem):
                 painter.drawLine(26, 26, 26, 22)
 
             if self.entity.config.renderPit:
-                Entity.PitAnm2.frame = self.getPitFrame(imgPath, rendered)
+                Entity.PitAnm2.frame = self.getPitFrame(imgPath, rendered, self.entity.config.renderPitExtraConnections)
                 Entity.PitAnm2.spritesheets[0] = rendered
                 rendered = self.scene().getFrame(imgPath + " - pit", Entity.PitAnm2)
                 renderFunc = painter.drawImage

--- a/NicheFeatures.md
+++ b/NicheFeatures.md
@@ -60,3 +60,19 @@ There is some subset of users who have found that the normal test launch method 
 
 ### Test Antibirth
 Anitbirth is capable of Instapreview testing for goofing around. In the absence of a true compatibility mode, you can quickly test rooms for poking its behavior. To test rooms in Anti, go to `settings.ini` and set `AntibirthPath` to the folder you have Antibirth installed in (formatted like `InstallPath`) and set `CompatibilityMode` to `Antibirth`. This only supports Instapreview. For Antibirth enemies, check out `resources/EntitiesAntibirth.xml`. Icon PRs welcome!
+
+### Tiling Pit Grids with other grids
+
+In case you have two grid entities that use pit tiling and need to tile with each other/other tiles other than themselves, you can use the `pitextra` sub-node for entities.
+
+An example:
+
+```xml
+<entity Image="..." EditorImage="mypit.png" UsePitTiling="1" [other attributes]>
+    <pitextra Image="otherpit.png"></pitextra>
+    <pitextra Image="arbitraryGrid.png"></pitextra>
+</entity>
+```
+
+In this example, the mypit.png pits will connect to tiles with the specified spritesheets (even if they do not use pit tiling themselves).
+Make sure if there is a different `EditorImage` in the specified entities to use the path to that spritesheet instead of Image.

--- a/src/lookup.py
+++ b/src/lookup.py
@@ -554,6 +554,7 @@ class EntityLookup(Lookup):
             self.placeVisual = None
             self.disableOffsetIndicator = False
             self.renderPit = False
+            self.renderPitExtraConnections: 'list|None' = None
             self.renderRock = False
             self.invalid = False
             self.gfx = None
@@ -624,6 +625,7 @@ class EntityLookup(Lookup):
             "placeVisual",
             "disableOffsetIndicator",
             "renderPit",
+            "renderPitExtraConnections",
             "renderRock",
             "mirrorX",
             "mirrorY",
@@ -748,6 +750,20 @@ class EntityLookup(Lookup):
 
             if node.get("UsePitTiling"):
                 self.renderPit = node.get("UsePitTiling") == "1"
+
+            pitextras = node.findall("pitextra")
+            if len(pitextras) != 0:
+                self.renderPitExtraConnections = []
+                for pitextraNode in pitextras:
+                    if "Image" in pitextraNode.attrib:
+                        self.renderPitExtraConnections.append(self.validateImagePath(
+                            pitextraNode.get("Image"),
+                            self.mod.resourcePath,
+                        ))
+                    else:
+                        printf(
+                            f"Entity {node.attrib} Has pitextra with no Image attribute: {pitextraNode}"
+                        )
 
             if node.get("UseRockTiling"):
                 self.renderRock = node.get("UseRockTiling") == "1"


### PR DESCRIPTION
Copying the feature description from the included doc in `NicheFeatures.md`:

---

In case you have two grid entities that use pit tiling and need to tile with each other/other tiles other than themselves, you can use the `pitextra` sub-node for entities.

An example:

```xml
<entity Image="..." EditorImage="mypit.png" UsePitTiling="1" [other attributes]>
    <pitextra Image="otherpit.png"></pitextra>
    <pitextra Image="arbitraryGrid.png"></pitextra>
</entity>
```

In this example, the mypit.png pits will connect to tiles with the specified spritesheets (even if they do not use pit tiling themselves).
Make sure if there is a different `EditorImage` in the specified entities to use the path to that spritesheet instead of Image.

---

Usecase: this would be useful for some WIP Revelations features.