### PR TITLE
Linux improvements

### DIFF
--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -43,7 +43,7 @@ import datetime
 import random
 import urllib.parse
 import urllib.request
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 import xml.etree.cElementTree as ET
 import psutil
 
@@ -6300,9 +6300,15 @@ class MainWindow(QMainWindow):
                     "",
                 )
 
+            # Prefix the file path with the root that Proton uses
+            # Only necessary for Repentance and Repentance+ as they don't have native Linux support.
+            isLinux = "Linux" in platform.system()
+            if version in ["Repentance", "Repentance+"] and isLinux:
+                modPath = "Z:\\" + modPath
+
             return (
                 [
-                    f"--load-room={path}",
+                    f"--load-room={PureWindowsPath(modPath) / testfile}",
                     f"--set-stage={floorInfo.get('Stage')}",
                     f"--set-stage-type={floorInfo.get('StageType')}",
                 ],

--- a/src/lookup.py
+++ b/src/lookup.py
@@ -215,7 +215,7 @@ class StageLookup(Lookup):
                 hasBasePath = lambda s: s.get("BaseGamePath") == baseGamePath
             stages = list(filter(hasBasePath, stages))
 
-        return stages
+        return stages[::-1]
 
     def getGfx(self, node):
         gfx = node.find("Gfx")


### PR DESCRIPTION
Added compatibility for Repentance(+) on Linux with Proton, and I also made the stages returned from the xml stages lookup return the array in reverse. This makes it so if it grabs multiple stages due to being provided a full file path (for example `/home/deck/.local/share/Steam/steamapps/common/The Binding of Isaac Rebirth/extracted_resources/resources/rooms/01.basement.xml` grabs both "home" and "basement"), it'll always use the later stage first, because the later stage will always be the one latest in the string.

Not sure if that second change has any adverse side effects, but everything seemed fine. Also haven't tested this on Windows haha.