### PR TITLE
Add "Set Paths" dialog for changing the install/mods/resources/exe paths

### DIFF
--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -4092,7 +4092,6 @@ class PathsDialog(QDialog):
             path = ""
             if self.isFile:
                 path, _ = QFileDialog.getOpenFileName(self.dialog, "Select " + self.labelText, startDir, "Executable files (*.exe)")
-                print(path)
             else:
                 path = QFileDialog.getExistingDirectory(self.dialog, "Select " + self.labelText, startDir)
 
@@ -4100,7 +4099,8 @@ class PathsDialog(QDialog):
                 self.setPath(path)
 
         def getCurrentPath(self):
-            """Returns the current value for this path.
+            """
+            Returns the current value for this path.
             Doesn't just read from the setting in order to trigger the usual auto-detection.
             """
             if self.getCurrentPathLambda:
@@ -4142,9 +4142,11 @@ class PathsDialog(QDialog):
                 self.resetButton.setEnabled(self.hasCustomizedPath())
 
         def setPath(self, path):
-            """Update the settings value and refresh widgets.
+            """
+            Update the settings value and refresh widgets.
             Setting to None will effectively revert it to the default value.
             """
+            print("setting", self.settingKey, "to", path)
             if self.isInstallFolder:
                 # If the InstallFolder is reset, also reset all other non-customized paths.
                 for pathSetting in self.dialog.pathSettings:
@@ -6715,8 +6717,11 @@ class MainWindow(QMainWindow):
             customExePath = settings.value("CustomExePath")
             useCustomExe = not forceUrlLaunch and QFile.exists(customExePath)
 
-            steamPath = getSteamPath()
-            useSteamExe = not forceUrlLaunch and not useCustomExe and steamPath and version != "Antibirth" and settings.value("ForceExeLaunch") != "1"
+            useSteamExe = False
+            steamPath = Nil
+            if not forceUrlLaunch and not useCustomExe and version != "Antibirth" and settings.value("ForceExeLaunch") != "1":
+                steamPath = getSteamPath()
+                useSteamExe = steamPath is not Nil
 
             exePath = None
 

--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -6718,10 +6718,10 @@ class MainWindow(QMainWindow):
             useCustomExe = not forceUrlLaunch and QFile.exists(customExePath)
 
             useSteamExe = False
-            steamPath = Nil
+            steamPath = None
             if not forceUrlLaunch and not useCustomExe and version != "Antibirth" and settings.value("ForceExeLaunch") != "1":
                 steamPath = getSteamPath()
-                useSteamExe = steamPath is not Nil
+                useSteamExe = steamPath is not None
 
             exePath = None
 

--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -4033,6 +4033,9 @@ class ReplaceDialog(QDialog):
 class PathsDialog(QDialog):
     """Dialog for modifying path settings (InstallFolder, ResourceFolder, etc)."""
 
+    LABEL_MAX_WIDTH = 85
+    BUTTON_WIDTH = 25
+
     class PathSetting:
         """Representation of (and widgets for) a specific path setting (InstallFolder, ResourceFolder, etc) within the PathsDialog."""
 
@@ -4060,6 +4063,7 @@ class PathsDialog(QDialog):
             self.labelText = labelText
             self.label = QLabel(self.labelText)
             self.label.setToolTip(tooltipText)
+            self.label.setMaximumWidth(PathsDialog.LABEL_MAX_WIDTH)
 
             self.textBox = QLineEdit()
             self.textBox.setReadOnly(True)
@@ -4073,6 +4077,8 @@ class PathsDialog(QDialog):
                 "Select " + ("file" if self.isFile else "folder")
             )
             self.selectButton.clicked.connect(lambda: self.selectNewPath())
+            self.selectButton.setMinimumWidth(PathsDialog.BUTTON_WIDTH)
+            self.selectButton.setMaximumWidth(PathsDialog.BUTTON_WIDTH)
 
             if not self.isInstallFolder:
                 self.resetButton = QPushButton()
@@ -4081,18 +4087,21 @@ class PathsDialog(QDialog):
                 )
                 self.resetButton.setToolTip("Reset to default")
                 self.resetButton.clicked.connect(lambda: self.setPath(None))
+                self.resetButton.setMinimumWidth(PathsDialog.BUTTON_WIDTH)
+                self.resetButton.setMaximumWidth(PathsDialog.BUTTON_WIDTH)
             else:
                 self.resetButton = None
 
-            self.refresh()
-
-        def addToGridLayout(self, gridLayout, rowNum):
-            """Add widgets to the given row in the provided QGridLayout."""
-            gridLayout.addWidget(self.label, rowNum, 0)
-            gridLayout.addWidget(self.textBox, rowNum, 1)
-            gridLayout.addWidget(self.selectButton, rowNum, 2)
+            self.layout = QHBoxLayout()
+            self.layout.addWidget(self.label, 1)
+            self.layout.addWidget(self.textBox, 1)
+            self.layout.addWidget(self.selectButton)
             if self.resetButton:
-                gridLayout.addWidget(self.resetButton, rowNum, 3)
+                self.layout.addWidget(self.resetButton)
+            else:
+                self.layout.addSpacing(PathsDialog.BUTTON_WIDTH + 6)
+
+            self.refresh()
 
         def selectNewPath(self):
             """Prompts the user to select a new folder/file."""
@@ -4260,21 +4269,22 @@ class PathsDialog(QDialog):
         ]
 
         # Create & populate the window layout.
-        gridLayout = QGridLayout()
+        layout = QVBoxLayout()
 
-        row = 0
         for pathSetting in self.pathSettings:
-            pathSetting.addToGridLayout(gridLayout, row)
-            row += 1
+            layout.addLayout(pathSetting.layout)
             if pathSetting.settingKey == "CustomExePath":
                 # Place the ForceUrlLaunch checkbox underneath the CustomExePath settings.
                 self.urlLaunchCheckbox.exePathSetting = pathSetting
-                gridLayout.addWidget(self.urlLaunchCheckbox, row, 1)
-                row += 1
+                forceUrlLaunchLayout = QHBoxLayout()
+                forceUrlLaunchLayout.addSpacing(PathsDialog.LABEL_MAX_WIDTH + 6)
+                forceUrlLaunchLayout.addWidget(self.urlLaunchCheckbox)
+                layout.addLayout(forceUrlLaunchLayout)
 
-        self.setLayout(gridLayout)
+        self.setLayout(layout)
         self.adjustSize()
-        self.resize(int(self.width() * 2), int(self.height()))  # Make the window wider
+        # Make the window wider
+        self.resize(int(self.width() * 2.5), int(self.height()))
 
 
 class HooksDialog(QDialog):

--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -4030,6 +4030,215 @@ class ReplaceDialog(QDialog):
         self.setLayout(layout)
 
 
+class PathsDialog(QDialog):
+	"""Dialog for modifying path settings (InstallFolder, ResourceFolder, etc)."""
+
+	class PathSetting():
+		"""Representation of (and widgets for) a specific path setting (InstallFolder, ResourceFolder, etc) within the PathsDialog."""
+
+		def __init__(self, dialog, labelText, settingKey, isFile=False, tooltipText="", getCurrentPathLambda=None, getDefaultPathLambda=None, disableLambda=None):
+			self.dialog = dialog
+			self.settingKey = settingKey
+			self.isFile = isFile
+			self.getCurrentPathLambda = getCurrentPathLambda
+			self.getDefaultPathLambda = getDefaultPathLambda
+			self.disableLambda = disableLambda
+
+			# InstallFolder has special treatment for a few things.
+			self.isInstallFolder = self.settingKey == "InstallFolder"
+
+			self.labelText = labelText
+			self.label = QLabel(self.labelText)
+			self.label.setToolTip(tooltipText)
+
+			self.textBox = QLineEdit()
+			self.textBox.setReadOnly(True)
+			self.textBox.setToolTip(tooltipText)
+
+			self.selectButton = QPushButton()
+			self.selectButton.setIcon(self.dialog.style().standardIcon(QStyle.SP_DirIcon))
+			self.selectButton.setToolTip("Select " + ("file" if self.isFile else "folder"))
+			self.selectButton.clicked.connect(
+				lambda: self.selectNewPath()
+			)
+
+			if not self.isInstallFolder:
+				self.resetButton = QPushButton()
+				self.resetButton.setIcon(self.dialog.style().standardIcon(QStyle.SP_TitleBarCloseButton))
+				self.resetButton.setToolTip("Reset to default")
+				self.resetButton.clicked.connect(
+					lambda: self.setPath(None)
+				)
+			else:
+				self.resetButton = None
+
+			self.refresh()
+
+		def addToGridLayout(self, gridLayout, rowNum):
+			"""Add widgets to the given row in the provided QGridLayout."""
+			gridLayout.addWidget(self.label, rowNum, 0)
+			gridLayout.addWidget(self.textBox, rowNum, 1)
+			gridLayout.addWidget(self.selectButton, rowNum, 2)
+			if self.resetButton:
+				gridLayout.addWidget(self.resetButton, rowNum, 3)
+
+		def selectNewPath(self):
+			"""Prompts the user to select a new folder/file."""
+			# Start the file dialog in the location of the current setting, or the install folder.
+			startDir = settings.value("InstallFolder")
+			if settings.value(self.settingKey):
+				startDir = settings.value(self.settingKey)
+
+			path = ""
+			if self.isFile:
+				path, _ = QFileDialog.getOpenFileName(self.dialog, "Select " + self.labelText, startDir, "Executable files (*.exe)")
+				print(path)
+			else:
+				path = QFileDialog.getExistingDirectory(self.dialog, "Select " + self.labelText, startDir)
+
+			if path:
+				self.setPath(path)
+
+		def getCurrentPath(self):
+			"""Returns the current value for this path.
+			Doesn't just read from the setting in order to trigger the usual auto-detection.
+			"""
+			if self.getCurrentPathLambda:
+				return os.path.normpath(self.getCurrentPathLambda())
+			return ""
+
+		def getDefaultPath(self):
+			"""Returns the "default" value for this path, relative to the current InstallPath."""
+			if self.getDefaultPathLambda:
+				return os.path.normpath(self.getDefaultPathLambda())
+			return ""
+
+		def hasCustomizedPath(self):
+			"""Returns true if this path setting has been customized (IE, is set to something besides the default)."""
+			return QFile.exists(settings.value(self.settingKey)) and os.path.realpath(self.getCurrentPath()) != os.path.realpath(self.getDefaultPath())
+
+		def refresh(self):
+			"""Refreshes widget contents to accurately represent the current state."""
+			currentPath = self.getCurrentPath()
+
+			if self.isInstallFolder or self.hasCustomizedPath():
+				# For customized paths and the InstallFolder, display the path normally.
+				self.textBox.setPlaceholderText("")
+				self.textBox.setText(currentPath)
+			else:
+				# For non-customized, non-InstallFolder path settings, display as greyed out placeholder text.
+				self.textBox.clear()
+				self.textBox.setPlaceholderText(currentPath)
+
+			if self.disableLambda:
+				# Disable row contents if lambda returns true.
+				disable = self.disableLambda()
+				self.label.setEnabled(not disable)
+				self.textBox.setEnabled(not disable)
+				self.selectButton.setEnabled(not disable)
+				if self.resetButton:
+					self.resetButton.setEnabled(not disable and self.hasCustomizedPath())
+			elif self.resetButton:
+				self.resetButton.setEnabled(self.hasCustomizedPath())
+
+		def setPath(self, path):
+			"""Update the settings value and refresh widgets.
+			Setting to None will effectively revert it to the default value.
+			"""
+			if self.isInstallFolder:
+				# If the InstallFolder is reset, also reset all other non-customized paths.
+				for pathSetting in self.dialog.pathSettings:
+					if not self.isInstallFolder and not pathSetting.hasCustomizedPath():
+						settings.remove(pathSetting.settingKey)
+
+			if not path:
+				settings.remove(self.settingKey)
+			else:
+				settings.setValue(self.settingKey, path)
+
+			if self.isInstallFolder:
+				# If the InstallFolder is reset, refresh everything.
+				for pathSetting in self.dialog.pathSettings:
+					pathSetting.refresh()
+			else:
+				self.refresh()
+
+	def updateUrlLaunchCheckbox(self):
+		"""Update the ForceUrlLaunch setting according to the checkbox, and refresh the widgets for the CustomExePath setting."""
+		if self.urlLaunchCheckbox:
+			settings.setValue("ForceUrlLaunch", "1" if self.urlLaunchCheckbox.isChecked() else "0")
+			if self.urlLaunchCheckbox.exePathSetting:
+				self.urlLaunchCheckbox.exePathSetting.refresh()
+
+	def __init__(self, parent):
+		super(QDialog, self).__init__(parent)
+		self.setWindowTitle("Set Paths")
+
+		# Remove the funny little question mark next to the close button.
+		self.setWindowFlags(self.windowFlags() & ~Qt.WindowType.WindowContextHelpButtonHint)
+
+		# Checkbox for the ForceUrlLaunch setting.
+		self.urlLaunchCheckbox = QCheckBox("Launch via Steam URL")
+		self.urlLaunchCheckbox.setChecked(settings.value("ForceUrlLaunch") == "1")
+		self.urlLaunchCheckbox.toggled.connect(
+			lambda: self.updateUrlLaunchCheckbox()
+		)
+
+		# Create the widgets/logic for each path setting, in the order they're displayed.
+		self.pathSettings = [
+			PathsDialog.PathSetting(
+				dialog = self,
+				labelText = "Install Folder",
+				settingKey = "InstallFolder",
+				tooltipText = "Directory in which The Binding of Isaac: Rebirth is installed.",
+				getCurrentPathLambda = lambda: findInstallPath(),
+			),
+			PathsDialog.PathSetting(
+				dialog = self,
+				labelText = "Resources Folder",
+				settingKey = "ResourceFolder",
+				tooltipText = "Folder containing vanilla game resources.",
+				getCurrentPathLambda = lambda: mainWindow.findResourcePath(),
+				getDefaultPathLambda = lambda: os.path.join(findInstallPath(), "resources"),
+			),
+			PathsDialog.PathSetting(
+				dialog = self,
+				labelText = "Mods Folder",
+				settingKey = "ModsFolder",
+				tooltipText = "Folder containing installed mods.",
+				getCurrentPathLambda = lambda: findModsPath(),
+				getDefaultPathLambda = lambda: os.path.join(findInstallPath(), "mods"),
+			),
+			PathsDialog.PathSetting(
+				dialog = self,
+				labelText = ".exe Path",
+				settingKey = "CustomExePath",
+				isFile = True,
+				tooltipText = "Path to the executable file to launch the game when testing rooms.",
+				getCurrentPathLambda = lambda: mainWindow.findExecutablePath(),
+				getDefaultPathLambda = lambda: os.path.join(findInstallPath(), "isaac-ng.exe"),
+				disableLambda = lambda: self.urlLaunchCheckbox.isChecked(),
+			),
+		]
+
+		# Create & populate the window layout.
+		gridLayout = QGridLayout()
+
+		row = 0
+		for pathSetting in self.pathSettings:
+			pathSetting.addToGridLayout(gridLayout, row)
+			row += 1
+			if pathSetting.settingKey == "CustomExePath":
+				# Place the ForceUrlLaunch checkbox underneath the CustomExePath settings.
+				self.urlLaunchCheckbox.exePathSetting = pathSetting
+				gridLayout.addWidget(self.urlLaunchCheckbox, row, 1)
+				row += 1
+
+		self.setLayout(gridLayout)
+		self.adjustSize()
+		self.resize(int(self.width() * 2), int(self.height()))  # Make the window wider
+
+
 class HooksDialog(QDialog):
     class HookItem(QListWidgetItem):
         def __init__(self, text, setting, tooltip):
@@ -5009,17 +5218,7 @@ class MainWindow(QMainWindow):
             QKeySequence("Ctrl+F10"),
         )
         f.addSeparator()
-        self.fh = f.addAction(
-            "Set Resources Path",
-            self.setDefaultResourcesPath,
-            QKeySequence("Ctrl+Shift+P"),
-        )
-        self.fi = f.addAction(
-            "Reset Resources Path",
-            self.resetResourcesPath,
-            QKeySequence("Ctrl+Shift+R"),
-        )
-        f.addSeparator()
+        self.fj = f.addAction("Set Paths", self.showSetPathsMenu)
         self.fj = f.addAction("Set Hooks", self.showHooksMenu)
         self.fl = f.addAction(
             "Autogenerate mod content (discouraged)",
@@ -5418,6 +5617,10 @@ class MainWindow(QMainWindow):
 
         self.dirt()
         self.roomList.changeFilter()
+
+    def showSetPathsMenu(self):
+        paths = PathsDialog(self)
+        paths.show()
 
     def setDefaultResourcesPath(self):
         settings = QSettings("settings.ini", QSettings.IniFormat)
@@ -6341,6 +6544,9 @@ class MainWindow(QMainWindow):
         self.testMapCommon("InstaPreview", setup)
 
     def findExecutablePath(self):
+        if QFile.exists(settings.value("CustomExePath")):
+            return settings.value("CustomExePath")
+
         if "Windows" in platform.system():
             installPath = findInstallPath()
             if installPath:
@@ -6504,11 +6710,19 @@ class MainWindow(QMainWindow):
         try:
             # try to run through steam to avoid steam confirmation popup, else run isaac directly
             # if there exists drm free copies, allow the direct exe launch method
-            steamPath = None
-            if version != "Antibirth" and settings.value("ForceExeLaunch") != "1":
-                steamPath = getSteamPath() or ""
+            forceUrlLaunch = settings.value("ForceUrlLaunch") == "1"
 
-            if steamPath:
+            customExePath = settings.value("CustomExePath")
+            useCustomExe = not forceUrlLaunch and QFile.exists(customExePath)
+
+            steamPath = getSteamPath()
+            useSteamExe = not forceUrlLaunch and not useCustomExe and steamPath and version != "Antibirth" and settings.value("ForceExeLaunch") != "1"
+
+            exePath = None
+
+            if useCustomExe:
+                exePath = customExePath
+            elif useSteamExe:
                 exePath = f"{steamPath}\\Steam.exe"
             else:
                 exePath = self.findExecutablePath()
@@ -6516,14 +6730,21 @@ class MainWindow(QMainWindow):
             if (
                 exePath
                 and QFile.exists(exePath)
-                and settings.value("ForceUrlLaunch") != "1"
+                and not forceUrlLaunch
             ):
-                if steamPath:
+                wd = installPath
+
+                if useCustomExe:
+                    # Pass a `--basement-renovator` flag to custom exes for identification purposes.
+                    # Note that if this flag does get passed to Isaac itself, it won't have any effect.
+                    launchArgs = ["--basement-renovator"] + launchArgs
+                    wd = os.path.dirname(exePath)
+                elif useSteamExe:
                     launchArgs = ["-applaunch", "250900"] + launchArgs
 
                 appArgs = [exePath] + launchArgs
                 printf("Test: Running executable", " ".join(appArgs))
-                subprocess.Popen(appArgs, cwd=installPath)
+                subprocess.Popen(appArgs, cwd=wd)
             else:
                 args = " ".join(map(lambda x: " " in x and f'"{x}"' or x, launchArgs))
                 urlArgs = urllib.parse.quote(args)

--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -4031,212 +4031,212 @@ class ReplaceDialog(QDialog):
 
 
 class PathsDialog(QDialog):
-	"""Dialog for modifying path settings (InstallFolder, ResourceFolder, etc)."""
+    """Dialog for modifying path settings (InstallFolder, ResourceFolder, etc)."""
 
-	class PathSetting():
-		"""Representation of (and widgets for) a specific path setting (InstallFolder, ResourceFolder, etc) within the PathsDialog."""
+    class PathSetting():
+        """Representation of (and widgets for) a specific path setting (InstallFolder, ResourceFolder, etc) within the PathsDialog."""
 
-		def __init__(self, dialog, labelText, settingKey, isFile=False, tooltipText="", getCurrentPathLambda=None, getDefaultPathLambda=None, disableLambda=None):
-			self.dialog = dialog
-			self.settingKey = settingKey
-			self.isFile = isFile
-			self.getCurrentPathLambda = getCurrentPathLambda
-			self.getDefaultPathLambda = getDefaultPathLambda
-			self.disableLambda = disableLambda
+        def __init__(self, dialog, labelText, settingKey, isFile=False, tooltipText="", getCurrentPathLambda=None, getDefaultPathLambda=None, disableLambda=None):
+            self.dialog = dialog
+            self.settingKey = settingKey
+            self.isFile = isFile
+            self.getCurrentPathLambda = getCurrentPathLambda
+            self.getDefaultPathLambda = getDefaultPathLambda
+            self.disableLambda = disableLambda
 
-			# InstallFolder has special treatment for a few things.
-			self.isInstallFolder = self.settingKey == "InstallFolder"
+            # InstallFolder has special treatment for a few things.
+            self.isInstallFolder = self.settingKey == "InstallFolder"
 
-			self.labelText = labelText
-			self.label = QLabel(self.labelText)
-			self.label.setToolTip(tooltipText)
+            self.labelText = labelText
+            self.label = QLabel(self.labelText)
+            self.label.setToolTip(tooltipText)
 
-			self.textBox = QLineEdit()
-			self.textBox.setReadOnly(True)
-			self.textBox.setToolTip(tooltipText)
+            self.textBox = QLineEdit()
+            self.textBox.setReadOnly(True)
+            self.textBox.setToolTip(tooltipText)
 
-			self.selectButton = QPushButton()
-			self.selectButton.setIcon(self.dialog.style().standardIcon(QStyle.SP_DirIcon))
-			self.selectButton.setToolTip("Select " + ("file" if self.isFile else "folder"))
-			self.selectButton.clicked.connect(
-				lambda: self.selectNewPath()
-			)
+            self.selectButton = QPushButton()
+            self.selectButton.setIcon(self.dialog.style().standardIcon(QStyle.SP_DirIcon))
+            self.selectButton.setToolTip("Select " + ("file" if self.isFile else "folder"))
+            self.selectButton.clicked.connect(
+                lambda: self.selectNewPath()
+            )
 
-			if not self.isInstallFolder:
-				self.resetButton = QPushButton()
-				self.resetButton.setIcon(self.dialog.style().standardIcon(QStyle.SP_TitleBarCloseButton))
-				self.resetButton.setToolTip("Reset to default")
-				self.resetButton.clicked.connect(
-					lambda: self.setPath(None)
-				)
-			else:
-				self.resetButton = None
+            if not self.isInstallFolder:
+                self.resetButton = QPushButton()
+                self.resetButton.setIcon(self.dialog.style().standardIcon(QStyle.SP_TitleBarCloseButton))
+                self.resetButton.setToolTip("Reset to default")
+                self.resetButton.clicked.connect(
+                    lambda: self.setPath(None)
+                )
+            else:
+                self.resetButton = None
 
-			self.refresh()
+            self.refresh()
 
-		def addToGridLayout(self, gridLayout, rowNum):
-			"""Add widgets to the given row in the provided QGridLayout."""
-			gridLayout.addWidget(self.label, rowNum, 0)
-			gridLayout.addWidget(self.textBox, rowNum, 1)
-			gridLayout.addWidget(self.selectButton, rowNum, 2)
-			if self.resetButton:
-				gridLayout.addWidget(self.resetButton, rowNum, 3)
+        def addToGridLayout(self, gridLayout, rowNum):
+            """Add widgets to the given row in the provided QGridLayout."""
+            gridLayout.addWidget(self.label, rowNum, 0)
+            gridLayout.addWidget(self.textBox, rowNum, 1)
+            gridLayout.addWidget(self.selectButton, rowNum, 2)
+            if self.resetButton:
+                gridLayout.addWidget(self.resetButton, rowNum, 3)
 
-		def selectNewPath(self):
-			"""Prompts the user to select a new folder/file."""
-			# Start the file dialog in the location of the current setting, or the install folder.
-			startDir = settings.value("InstallFolder")
-			if settings.value(self.settingKey):
-				startDir = settings.value(self.settingKey)
+        def selectNewPath(self):
+            """Prompts the user to select a new folder/file."""
+            # Start the file dialog in the location of the current setting, or the install folder.
+            startDir = settings.value("InstallFolder")
+            if settings.value(self.settingKey):
+                startDir = settings.value(self.settingKey)
 
-			path = ""
-			if self.isFile:
-				path, _ = QFileDialog.getOpenFileName(self.dialog, "Select " + self.labelText, startDir, "Executable files (*.exe)")
-				print(path)
-			else:
-				path = QFileDialog.getExistingDirectory(self.dialog, "Select " + self.labelText, startDir)
+            path = ""
+            if self.isFile:
+                path, _ = QFileDialog.getOpenFileName(self.dialog, "Select " + self.labelText, startDir, "Executable files (*.exe)")
+                print(path)
+            else:
+                path = QFileDialog.getExistingDirectory(self.dialog, "Select " + self.labelText, startDir)
 
-			if path:
-				self.setPath(path)
+            if path:
+                self.setPath(path)
 
-		def getCurrentPath(self):
-			"""Returns the current value for this path.
-			Doesn't just read from the setting in order to trigger the usual auto-detection.
-			"""
-			if self.getCurrentPathLambda:
-				return os.path.normpath(self.getCurrentPathLambda())
-			return ""
+        def getCurrentPath(self):
+            """Returns the current value for this path.
+            Doesn't just read from the setting in order to trigger the usual auto-detection.
+            """
+            if self.getCurrentPathLambda:
+                return os.path.normpath(self.getCurrentPathLambda())
+            return ""
 
-		def getDefaultPath(self):
-			"""Returns the "default" value for this path, relative to the current InstallPath."""
-			if self.getDefaultPathLambda:
-				return os.path.normpath(self.getDefaultPathLambda())
-			return ""
+        def getDefaultPath(self):
+            """Returns the "default" value for this path, relative to the current InstallPath."""
+            if self.getDefaultPathLambda:
+                return os.path.normpath(self.getDefaultPathLambda())
+            return ""
 
-		def hasCustomizedPath(self):
-			"""Returns true if this path setting has been customized (IE, is set to something besides the default)."""
-			return QFile.exists(settings.value(self.settingKey)) and os.path.realpath(self.getCurrentPath()) != os.path.realpath(self.getDefaultPath())
+        def hasCustomizedPath(self):
+            """Returns true if this path setting has been customized (IE, is set to something besides the default)."""
+            return QFile.exists(settings.value(self.settingKey)) and os.path.realpath(self.getCurrentPath()) != os.path.realpath(self.getDefaultPath())
 
-		def refresh(self):
-			"""Refreshes widget contents to accurately represent the current state."""
-			currentPath = self.getCurrentPath()
+        def refresh(self):
+            """Refreshes widget contents to accurately represent the current state."""
+            currentPath = self.getCurrentPath()
 
-			if self.isInstallFolder or self.hasCustomizedPath():
-				# For customized paths and the InstallFolder, display the path normally.
-				self.textBox.setPlaceholderText("")
-				self.textBox.setText(currentPath)
-			else:
-				# For non-customized, non-InstallFolder path settings, display as greyed out placeholder text.
-				self.textBox.clear()
-				self.textBox.setPlaceholderText(currentPath)
+            if self.isInstallFolder or self.hasCustomizedPath():
+                # For customized paths and the InstallFolder, display the path normally.
+                self.textBox.setPlaceholderText("")
+                self.textBox.setText(currentPath)
+            else:
+                # For non-customized, non-InstallFolder path settings, display as greyed out placeholder text.
+                self.textBox.clear()
+                self.textBox.setPlaceholderText(currentPath)
 
-			if self.disableLambda:
-				# Disable row contents if lambda returns true.
-				disable = self.disableLambda()
-				self.label.setEnabled(not disable)
-				self.textBox.setEnabled(not disable)
-				self.selectButton.setEnabled(not disable)
-				if self.resetButton:
-					self.resetButton.setEnabled(not disable and self.hasCustomizedPath())
-			elif self.resetButton:
-				self.resetButton.setEnabled(self.hasCustomizedPath())
+            if self.disableLambda:
+                # Disable row contents if lambda returns true.
+                disable = self.disableLambda()
+                self.label.setEnabled(not disable)
+                self.textBox.setEnabled(not disable)
+                self.selectButton.setEnabled(not disable)
+                if self.resetButton:
+                    self.resetButton.setEnabled(not disable and self.hasCustomizedPath())
+            elif self.resetButton:
+                self.resetButton.setEnabled(self.hasCustomizedPath())
 
-		def setPath(self, path):
-			"""Update the settings value and refresh widgets.
-			Setting to None will effectively revert it to the default value.
-			"""
-			if self.isInstallFolder:
-				# If the InstallFolder is reset, also reset all other non-customized paths.
-				for pathSetting in self.dialog.pathSettings:
-					if not self.isInstallFolder and not pathSetting.hasCustomizedPath():
-						settings.remove(pathSetting.settingKey)
+        def setPath(self, path):
+            """Update the settings value and refresh widgets.
+            Setting to None will effectively revert it to the default value.
+            """
+            if self.isInstallFolder:
+                # If the InstallFolder is reset, also reset all other non-customized paths.
+                for pathSetting in self.dialog.pathSettings:
+                    if not self.isInstallFolder and not pathSetting.hasCustomizedPath():
+                        settings.remove(pathSetting.settingKey)
 
-			if not path:
-				settings.remove(self.settingKey)
-			else:
-				settings.setValue(self.settingKey, path)
+            if not path:
+                settings.remove(self.settingKey)
+            else:
+                settings.setValue(self.settingKey, path)
 
-			if self.isInstallFolder:
-				# If the InstallFolder is reset, refresh everything.
-				for pathSetting in self.dialog.pathSettings:
-					pathSetting.refresh()
-			else:
-				self.refresh()
+            if self.isInstallFolder:
+                # If the InstallFolder is reset, refresh everything.
+                for pathSetting in self.dialog.pathSettings:
+                    pathSetting.refresh()
+            else:
+                self.refresh()
 
-	def updateUrlLaunchCheckbox(self):
-		"""Update the ForceUrlLaunch setting according to the checkbox, and refresh the widgets for the CustomExePath setting."""
-		if self.urlLaunchCheckbox:
-			settings.setValue("ForceUrlLaunch", "1" if self.urlLaunchCheckbox.isChecked() else "0")
-			if self.urlLaunchCheckbox.exePathSetting:
-				self.urlLaunchCheckbox.exePathSetting.refresh()
+    def updateUrlLaunchCheckbox(self):
+        """Update the ForceUrlLaunch setting according to the checkbox, and refresh the widgets for the CustomExePath setting."""
+        if self.urlLaunchCheckbox:
+            settings.setValue("ForceUrlLaunch", "1" if self.urlLaunchCheckbox.isChecked() else "0")
+            if self.urlLaunchCheckbox.exePathSetting:
+                self.urlLaunchCheckbox.exePathSetting.refresh()
 
-	def __init__(self, parent):
-		super(QDialog, self).__init__(parent)
-		self.setWindowTitle("Set Paths")
+    def __init__(self, parent):
+        super(QDialog, self).__init__(parent)
+        self.setWindowTitle("Set Paths")
 
-		# Remove the funny little question mark next to the close button.
-		self.setWindowFlags(self.windowFlags() & ~Qt.WindowType.WindowContextHelpButtonHint)
+        # Remove the funny little question mark next to the close button.
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowType.WindowContextHelpButtonHint)
 
-		# Checkbox for the ForceUrlLaunch setting.
-		self.urlLaunchCheckbox = QCheckBox("Launch via Steam URL")
-		self.urlLaunchCheckbox.setChecked(settings.value("ForceUrlLaunch") == "1")
-		self.urlLaunchCheckbox.toggled.connect(
-			lambda: self.updateUrlLaunchCheckbox()
-		)
+        # Checkbox for the ForceUrlLaunch setting.
+        self.urlLaunchCheckbox = QCheckBox("Launch via Steam URL")
+        self.urlLaunchCheckbox.setChecked(settings.value("ForceUrlLaunch") == "1")
+        self.urlLaunchCheckbox.toggled.connect(
+            lambda: self.updateUrlLaunchCheckbox()
+        )
 
-		# Create the widgets/logic for each path setting, in the order they're displayed.
-		self.pathSettings = [
-			PathsDialog.PathSetting(
-				dialog = self,
-				labelText = "Install Folder",
-				settingKey = "InstallFolder",
-				tooltipText = "Directory in which The Binding of Isaac: Rebirth is installed.",
-				getCurrentPathLambda = lambda: findInstallPath(),
-			),
-			PathsDialog.PathSetting(
-				dialog = self,
-				labelText = "Resources Folder",
-				settingKey = "ResourceFolder",
-				tooltipText = "Folder containing vanilla game resources.",
-				getCurrentPathLambda = lambda: mainWindow.findResourcePath(),
-				getDefaultPathLambda = lambda: os.path.join(findInstallPath(), "resources"),
-			),
-			PathsDialog.PathSetting(
-				dialog = self,
-				labelText = "Mods Folder",
-				settingKey = "ModsFolder",
-				tooltipText = "Folder containing installed mods.",
-				getCurrentPathLambda = lambda: findModsPath(),
-				getDefaultPathLambda = lambda: os.path.join(findInstallPath(), "mods"),
-			),
-			PathsDialog.PathSetting(
-				dialog = self,
-				labelText = ".exe Path",
-				settingKey = "CustomExePath",
-				isFile = True,
-				tooltipText = "Path to the executable file to launch the game when testing rooms.",
-				getCurrentPathLambda = lambda: mainWindow.findExecutablePath(),
-				getDefaultPathLambda = lambda: os.path.join(findInstallPath(), "isaac-ng.exe"),
-				disableLambda = lambda: self.urlLaunchCheckbox.isChecked(),
-			),
-		]
+        # Create the widgets/logic for each path setting, in the order they're displayed.
+        self.pathSettings = [
+            PathsDialog.PathSetting(
+                dialog = self,
+                labelText = "Install Folder",
+                settingKey = "InstallFolder",
+                tooltipText = "Directory in which The Binding of Isaac: Rebirth is installed.",
+                getCurrentPathLambda = lambda: findInstallPath(),
+            ),
+            PathsDialog.PathSetting(
+                dialog = self,
+                labelText = "Resources Folder",
+                settingKey = "ResourceFolder",
+                tooltipText = "Folder containing vanilla game resources.",
+                getCurrentPathLambda = lambda: mainWindow.findResourcePath(),
+                getDefaultPathLambda = lambda: os.path.join(findInstallPath(), "resources"),
+            ),
+            PathsDialog.PathSetting(
+                dialog = self,
+                labelText = "Mods Folder",
+                settingKey = "ModsFolder",
+                tooltipText = "Folder containing installed mods.",
+                getCurrentPathLambda = lambda: findModsPath(),
+                getDefaultPathLambda = lambda: os.path.join(findInstallPath(), "mods"),
+            ),
+            PathsDialog.PathSetting(
+                dialog = self,
+                labelText = ".exe Path",
+                settingKey = "CustomExePath",
+                isFile = True,
+                tooltipText = "Path to the executable file to launch the game when testing rooms.",
+                getCurrentPathLambda = lambda: mainWindow.findExecutablePath(),
+                getDefaultPathLambda = lambda: os.path.join(findInstallPath(), "isaac-ng.exe"),
+                disableLambda = lambda: self.urlLaunchCheckbox.isChecked(),
+            ),
+        ]
 
-		# Create & populate the window layout.
-		gridLayout = QGridLayout()
+        # Create & populate the window layout.
+        gridLayout = QGridLayout()
 
-		row = 0
-		for pathSetting in self.pathSettings:
-			pathSetting.addToGridLayout(gridLayout, row)
-			row += 1
-			if pathSetting.settingKey == "CustomExePath":
-				# Place the ForceUrlLaunch checkbox underneath the CustomExePath settings.
-				self.urlLaunchCheckbox.exePathSetting = pathSetting
-				gridLayout.addWidget(self.urlLaunchCheckbox, row, 1)
-				row += 1
+        row = 0
+        for pathSetting in self.pathSettings:
+            pathSetting.addToGridLayout(gridLayout, row)
+            row += 1
+            if pathSetting.settingKey == "CustomExePath":
+                # Place the ForceUrlLaunch checkbox underneath the CustomExePath settings.
+                self.urlLaunchCheckbox.exePathSetting = pathSetting
+                gridLayout.addWidget(self.urlLaunchCheckbox, row, 1)
+                row += 1
 
-		self.setLayout(gridLayout)
-		self.adjustSize()
-		self.resize(int(self.width() * 2), int(self.height()))  # Make the window wider
+        self.setLayout(gridLayout)
+        self.adjustSize()
+        self.resize(int(self.width() * 2), int(self.height()))  # Make the window wider
 
 
 class HooksDialog(QDialog):

--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -4033,10 +4033,20 @@ class ReplaceDialog(QDialog):
 class PathsDialog(QDialog):
     """Dialog for modifying path settings (InstallFolder, ResourceFolder, etc)."""
 
-    class PathSetting():
+    class PathSetting:
         """Representation of (and widgets for) a specific path setting (InstallFolder, ResourceFolder, etc) within the PathsDialog."""
 
-        def __init__(self, dialog, labelText, settingKey, isFile=False, tooltipText="", getCurrentPathLambda=None, getDefaultPathLambda=None, disableLambda=None):
+        def __init__(
+            self,
+            dialog,
+            labelText,
+            settingKey,
+            isFile=False,
+            tooltipText="",
+            getCurrentPathLambda=None,
+            getDefaultPathLambda=None,
+            disableLambda=None,
+        ):
             self.dialog = dialog
             self.settingKey = settingKey
             self.isFile = isFile
@@ -4056,19 +4066,21 @@ class PathsDialog(QDialog):
             self.textBox.setToolTip(tooltipText)
 
             self.selectButton = QPushButton()
-            self.selectButton.setIcon(self.dialog.style().standardIcon(QStyle.SP_DirIcon))
-            self.selectButton.setToolTip("Select " + ("file" if self.isFile else "folder"))
-            self.selectButton.clicked.connect(
-                lambda: self.selectNewPath()
+            self.selectButton.setIcon(
+                self.dialog.style().standardIcon(QStyle.SP_DirIcon)
             )
+            self.selectButton.setToolTip(
+                "Select " + ("file" if self.isFile else "folder")
+            )
+            self.selectButton.clicked.connect(lambda: self.selectNewPath())
 
             if not self.isInstallFolder:
                 self.resetButton = QPushButton()
-                self.resetButton.setIcon(self.dialog.style().standardIcon(QStyle.SP_TitleBarCloseButton))
-                self.resetButton.setToolTip("Reset to default")
-                self.resetButton.clicked.connect(
-                    lambda: self.setPath(None)
+                self.resetButton.setIcon(
+                    self.dialog.style().standardIcon(QStyle.SP_TitleBarCloseButton)
                 )
+                self.resetButton.setToolTip("Reset to default")
+                self.resetButton.clicked.connect(lambda: self.setPath(None))
             else:
                 self.resetButton = None
 
@@ -4092,9 +4104,16 @@ class PathsDialog(QDialog):
 
             path = ""
             if self.isFile:
-                path, _ = QFileDialog.getOpenFileName(self.dialog, "Select " + self.labelText, startDir, "Executable files (*.exe)")
+                path, _ = QFileDialog.getOpenFileName(
+                    self.dialog,
+                    "Select " + self.labelText,
+                    startDir,
+                    "Executable files (*.exe)",
+                )
             else:
-                path = QFileDialog.getExistingDirectory(self.dialog, "Select " + self.labelText, startDir)
+                path = QFileDialog.getExistingDirectory(
+                    self.dialog, "Select " + self.labelText, startDir
+                )
 
             if path:
                 self.setPath(path)
@@ -4120,7 +4139,9 @@ class PathsDialog(QDialog):
 
         def hasCustomizedPath(self):
             """Returns true if this path setting has been customized (IE, is set to something besides the default)."""
-            return QFile.exists(settings.value(self.settingKey)) and os.path.realpath(self.getCurrentPath()) != os.path.realpath(self.getDefaultPath())
+            return QFile.exists(settings.value(self.settingKey)) and os.path.realpath(
+                self.getCurrentPath()
+            ) != os.path.realpath(self.getDefaultPath())
 
         def refresh(self):
             """Refreshes widget contents to accurately represent the current state."""
@@ -4142,7 +4163,9 @@ class PathsDialog(QDialog):
                 self.textBox.setEnabled(not disable)
                 self.selectButton.setEnabled(not disable)
                 if self.resetButton:
-                    self.resetButton.setEnabled(not disable and self.hasCustomizedPath())
+                    self.resetButton.setEnabled(
+                        not disable and self.hasCustomizedPath()
+                    )
             elif self.resetButton:
                 self.resetButton.setEnabled(self.hasCustomizedPath())
 
@@ -4173,7 +4196,9 @@ class PathsDialog(QDialog):
     def updateUrlLaunchCheckbox(self):
         """Update the ForceUrlLaunch setting according to the checkbox, and refresh the widgets for the CustomExePath setting."""
         if self.urlLaunchCheckbox:
-            settings.setValue("ForceUrlLaunch", "1" if self.urlLaunchCheckbox.isChecked() else "0")
+            settings.setValue(
+                "ForceUrlLaunch", "1" if self.urlLaunchCheckbox.isChecked() else "0"
+            )
             if self.urlLaunchCheckbox.exePathSetting:
                 self.urlLaunchCheckbox.exePathSetting.refresh()
 
@@ -4182,51 +4207,55 @@ class PathsDialog(QDialog):
         self.setWindowTitle("Set Paths")
 
         # Remove the funny little question mark next to the close button.
-        self.setWindowFlags(self.windowFlags() & ~Qt.WindowType.WindowContextHelpButtonHint)
+        self.setWindowFlags(
+            self.windowFlags() & ~Qt.WindowType.WindowContextHelpButtonHint
+        )
 
         # Checkbox for the ForceUrlLaunch setting.
         self.urlLaunchCheckbox = QCheckBox("Launch via Steam URL")
         self.urlLaunchCheckbox.setChecked(settings.value("ForceUrlLaunch") == "1")
-        self.urlLaunchCheckbox.toggled.connect(
-            lambda: self.updateUrlLaunchCheckbox()
-        )
+        self.urlLaunchCheckbox.toggled.connect(lambda: self.updateUrlLaunchCheckbox())
 
         # Create the widgets/logic for each path setting, in the order they're displayed.
         # Note: The "default" values provided by the lambdas here are not used to populate
         # the setting, they are used to determine if the current setting is customized.
         self.pathSettings = [
             PathsDialog.PathSetting(
-                dialog = self,
-                labelText = "Install Folder",
-                settingKey = "InstallFolder",
-                tooltipText = "Directory in which The Binding of Isaac: Rebirth is installed.",
-                getCurrentPathLambda = lambda: findInstallPath(),
+                dialog=self,
+                labelText="Install Folder",
+                settingKey="InstallFolder",
+                tooltipText="Directory in which The Binding of Isaac: Rebirth is installed.",
+                getCurrentPathLambda=lambda: findInstallPath(),
             ),
             PathsDialog.PathSetting(
-                dialog = self,
-                labelText = "Resources Folder",
-                settingKey = "ResourceFolder",
-                tooltipText = "Folder containing vanilla game resources.",
-                getCurrentPathLambda = lambda: mainWindow.findResourcePath(),
-                getDefaultPathLambda = lambda: os.path.join(findInstallPath(), "resources"),
+                dialog=self,
+                labelText="Resources Folder",
+                settingKey="ResourceFolder",
+                tooltipText="Folder containing vanilla game resources.",
+                getCurrentPathLambda=lambda: mainWindow.findResourcePath(),
+                getDefaultPathLambda=lambda: os.path.join(
+                    findInstallPath(), "resources"
+                ),
             ),
             PathsDialog.PathSetting(
-                dialog = self,
-                labelText = "Mods Folder",
-                settingKey = "ModsFolder",
-                tooltipText = "Folder containing installed mods.",
-                getCurrentPathLambda = lambda: findModsPath(),
-                getDefaultPathLambda = lambda: os.path.join(findInstallPath(), "mods"),
+                dialog=self,
+                labelText="Mods Folder",
+                settingKey="ModsFolder",
+                tooltipText="Folder containing installed mods.",
+                getCurrentPathLambda=lambda: findModsPath(),
+                getDefaultPathLambda=lambda: os.path.join(findInstallPath(), "mods"),
             ),
             PathsDialog.PathSetting(
-                dialog = self,
-                labelText = ".exe Path",
-                settingKey = "CustomExePath",
-                isFile = True,
-                tooltipText = "Path to the executable file to launch the game when testing rooms.",
-                getCurrentPathLambda = lambda: mainWindow.findExecutablePath(),
-                getDefaultPathLambda = lambda: os.path.join(findInstallPath(), "isaac-ng.exe"),
-                disableLambda = lambda: self.urlLaunchCheckbox.isChecked(),
+                dialog=self,
+                labelText=".exe Path",
+                settingKey="CustomExePath",
+                isFile=True,
+                tooltipText="Path to the executable file to launch the game when testing rooms.",
+                getCurrentPathLambda=lambda: mainWindow.findExecutablePath(),
+                getDefaultPathLambda=lambda: os.path.join(
+                    findInstallPath(), "isaac-ng.exe"
+                ),
+                disableLambda=lambda: self.urlLaunchCheckbox.isChecked(),
             ),
         ]
 
@@ -6726,7 +6755,12 @@ class MainWindow(QMainWindow):
 
             useSteamExe = False
             steamPath = None
-            if not forceUrlLaunch and not useCustomExe and version != "Antibirth" and settings.value("ForceExeLaunch") != "1":
+            if (
+                not forceUrlLaunch
+                and not useCustomExe
+                and version != "Antibirth"
+                and settings.value("ForceExeLaunch") != "1"
+            ):
                 steamPath = getSteamPath()
                 useSteamExe = steamPath is not None
 
@@ -6739,11 +6773,7 @@ class MainWindow(QMainWindow):
             else:
                 exePath = self.findExecutablePath()
 
-            if (
-                exePath
-                and QFile.exists(exePath)
-                and not forceUrlLaunch
-            ):
+            if exePath and QFile.exists(exePath) and not forceUrlLaunch:
                 wd = installPath
 
                 if useCustomExe:

--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -4086,8 +4086,9 @@ class PathsDialog(QDialog):
             """Prompts the user to select a new folder/file."""
             # Start the file dialog in the location of the current setting, or the install folder.
             startDir = settings.value("InstallFolder")
-            if settings.value(self.settingKey):
-                startDir = settings.value(self.settingKey)
+            currentPath = self.getCurrentPath()
+            if QFile.exists(currentPath):
+                startDir = currentPath
 
             path = ""
             if self.isFile:
@@ -4108,7 +4109,11 @@ class PathsDialog(QDialog):
             return ""
 
         def getDefaultPath(self):
-            """Returns the "default" value for this path, relative to the current InstallPath."""
+            """
+            Returns the "default" value for this path, relative to the current InstallPath.
+            Note: This value is never written to the settings. It is only used to determine if
+            the current setting is "customized" or not.
+            """
             if self.getDefaultPathLambda:
                 return os.path.normpath(self.getDefaultPathLambda())
             return ""
@@ -4187,6 +4192,8 @@ class PathsDialog(QDialog):
         )
 
         # Create the widgets/logic for each path setting, in the order they're displayed.
+        # Note: The "default" values provided by the lambdas here are not used to populate
+        # the setting, they are used to determine if the current setting is customized.
         self.pathSettings = [
             PathsDialog.PathSetting(
                 dialog = self,

--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -4077,8 +4077,7 @@ class PathsDialog(QDialog):
                 "Select " + ("file" if self.isFile else "folder")
             )
             self.selectButton.clicked.connect(lambda: self.selectNewPath())
-            self.selectButton.setMinimumWidth(PathsDialog.BUTTON_WIDTH)
-            self.selectButton.setMaximumWidth(PathsDialog.BUTTON_WIDTH)
+            self.selectButton.setFixedWidth(PathsDialog.BUTTON_WIDTH)
 
             if not self.isInstallFolder:
                 self.resetButton = QPushButton()
@@ -4087,8 +4086,7 @@ class PathsDialog(QDialog):
                 )
                 self.resetButton.setToolTip("Reset to default")
                 self.resetButton.clicked.connect(lambda: self.setPath(None))
-                self.resetButton.setMinimumWidth(PathsDialog.BUTTON_WIDTH)
-                self.resetButton.setMaximumWidth(PathsDialog.BUTTON_WIDTH)
+                self.resetButton.setFixedWidth(PathsDialog.BUTTON_WIDTH)
             else:
                 self.resetButton = None
 


### PR DESCRIPTION
Replaces the existing "Set Resources Path" and "Reset Resources Path" actions with a new "Set Paths" action that opens a new window for modifying the install/mods/resources/exe path settings.

Previously, modifying the existing installation/mods paths in the gui was not possible. The ability to set (and save) a custom exe path is new, and enables support for alternative game launch methods (such as the upcoming REPENTOGON Launcher application).

<img width="631" height="197" alt="image" src="https://github.com/user-attachments/assets/010ed1c4-4048-4af1-b406-a06af652b737" />

Paths are greyed out if they are not customized.