### PR TITLE
Fix issues/inconsistencies with stage lookups

### DIFF
--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -2497,9 +2497,8 @@ class Room(QListWidgetItem):
             self.roomBG = val
             return
 
-        matchPath = mainWindow.path and os.path.split(mainWindow.path)[1]
         self.roomBG = xmlLookups.getRoomGfx(
-            room=self, roomfile=mainWindow.roomList.file, path=matchPath
+            room=self, roomfile=mainWindow.roomList.file, path=mainWindow.path
         )
 
     def mirrorX(self):

--- a/BasementRenovator.py
+++ b/BasementRenovator.py
@@ -5672,7 +5672,7 @@ class MainWindow(QMainWindow):
         self.roomList.list.clear()
         self.scene.clear()
         self.path = ""
-        self.floorInfo = xmlLookups.stages.lookup(name="Basement")[-1]
+        self.floorInfo = xmlLookups.stages.lookupOne(name="Basement")
 
         self.dirt()
         self.roomList.changeFilter()
@@ -5846,10 +5846,9 @@ class MainWindow(QMainWindow):
         self.path = path
 
         global xmlLookups
-        self.floorInfo = (
-            xmlLookups.stages.lookup(path=self.path)
-            or xmlLookups.stages.lookup(name="Basement")
-        )[-1]
+        self.floorInfo = xmlLookups.stages.lookupOne(
+            path=self.path
+        ) or xmlLookups.stages.lookupOne(name="Basement")
 
         roomFile = None
         try:
@@ -6512,12 +6511,12 @@ class MainWindow(QMainWindow):
                     raise
 
                 baseSpecialPath = "00.special rooms"
-                extraInfo = xmlLookups.stages.lookup(
+                extraInfo = xmlLookups.stages.lookupOne(
                     stage=floorInfo.get("Stage"),
                     stageType=floorInfo.get("StageType"),
                     baseGamePath=True,
                 )
-                basePath = floorInfo.get("BaseGamePath") or extraInfo[-1].get(
+                basePath = floorInfo.get("BaseGamePath") or extraInfo.get(
                     "BaseGamePath"
                 )
 


### PR DESCRIPTION
`xmlLookups.stages.lookup(path=path)` will retrieve all stages whose "Pattern" value is present anywhere in the path string. Currently, these results are in their xml ordering. The last element in the return value is picked in most existing cases.

This can cause odd behaviour if the path happens to contain multiple valid stage names. A notable example is a linux-style path like `/home/.../basement.xml`, which will test the stage in home instead of basement, since home is later in the xml ordering.

In contrast, the decision of which stage to use for the room editor backdrop is only based on the filename, not the whole path. This leads to some inconsistencies where `/home/.../basement.xml` will show basement in the room editor but run tests in home. Additionally, a path like `.../depths/rooms.xml` will not show the depths backdrop in the room editor, but it WILL load depths when testing rooms.

This PR introduces the following changes:
1. In `StageLookup.lookup()`, after filtering to stages whose "Pattern" exists in the path, split the path into parts and sort the stages by the index of the LAST part that they match to. Since python sorts are stable, if multiple stages match to the same part, they remain in their previous xml ordering (so while "burning basement" can match Basement too, Burning Basement will win out like it does currently).
2. In `Room.setRoomBG()`, pass the whole filepath instead of just the filename, for consistency between the selection of the room editor backdrop and the stage loaded for tests.
3. In `RoomTypeLookup.filterRoom()`, update the stage lookup to only look at the last element in the result to account for the full path being provided now instead of just the filename, and consistency with other stage lookups.

The new sorting logic for path-based stage filters will order results in ways like this:
`/home/test/basement.xml` -> [Home, Basement]
`\basement\home\room.xml` -> [Basement, Home]
`C:\home\basement\home.xml` -> [Basement, Home]
`./home/bluewomb/rooms.xml` -> [Home, Womb, Blue Womb]
`basementrenovator/burning basement.xml` -> [Basement, Burning Basement]

Tested by artificially creating xmls with paths like the above and verifying the expected behaviour for both the room editor backdrop and when launching tests. Also tested with Glacier (Revelations) rooms with StageAPI hooks, and vanilla room files such as burning basement, flooded caves, greedmode shop floor, the special rooms file, etc.